### PR TITLE
bugfix/list-placeholder-is-cleared-when-no-values-are-present

### DIFF
--- a/src/main/java/io/knowledgeassets/myskills/server/user/profile/UserProfileDocumentService.java
+++ b/src/main/java/io/knowledgeassets/myskills/server/user/profile/UserProfileDocumentService.java
@@ -183,7 +183,7 @@ public class UserProfileDocumentService {
 		final String text = r.getText(0);
 		if (StringUtils.containsIgnoreCase(text, placeholder)) {
 			final List<String> values = valuesSupplier.get();
-			if (values == null) {
+			if (values == null || values.isEmpty()) {
 				final String newText = StringUtils.replaceIgnoreCase(text, placeholder, "N/A");
 				// remove bullet styling
 				paragraph.getCTP().unsetPPr();


### PR DESCRIPTION
If no list values are present the list placeholder is replaced with an empty value.