### PR TITLE
feature/SKOOP-117

### DIFF
--- a/src/main/java/io/knowledgeassets/myskills/server/community/CommunityDeletedNotificationResponse.java
+++ b/src/main/java/io/knowledgeassets/myskills/server/community/CommunityDeletedNotificationResponse.java
@@ -1,5 +1,6 @@
 package io.knowledgeassets.myskills.server.community;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import io.knowledgeassets.myskills.server.notification.AbstractNotificationResponse;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -18,6 +19,7 @@ import java.time.LocalDateTime;
 		description = "This holds notification data about community deletion. " +
 				"It is used to transfer community deleted notification data to a client."
 )
+@JsonTypeName("CommunityDeletedNotification")
 public class CommunityDeletedNotificationResponse extends AbstractNotificationResponse {
 
 	@ApiModelProperty("Name of deleted community.")

--- a/src/main/java/io/knowledgeassets/myskills/server/communityuser/CommunityUserRoleChangedNotification.java
+++ b/src/main/java/io/knowledgeassets/myskills/server/communityuser/CommunityUserRoleChangedNotification.java
@@ -1,0 +1,35 @@
+package io.knowledgeassets.myskills.server.communityuser;
+
+import io.knowledgeassets.myskills.server.community.CommunityRole;
+import io.knowledgeassets.myskills.server.notification.Notification;
+import io.knowledgeassets.myskills.server.user.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.neo4j.ogm.annotation.Property;
+import org.neo4j.ogm.annotation.Relationship;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommunityUserRoleChangedNotification extends Notification {
+
+	@Property(name = "communityName")
+	private String communityName;
+	@Property(name = "role")
+	private CommunityRole role;
+	@Relationship(type = "USER")
+	private User user;
+
+	@Builder
+	public CommunityUserRoleChangedNotification(String id, LocalDateTime creationDatetime, String communityName, CommunityRole role, User user) {
+		super(id, creationDatetime);
+		this.communityName = communityName;
+		this.role = role;
+		this.user = user;
+	}
+
+}

--- a/src/main/java/io/knowledgeassets/myskills/server/communityuser/CommunityUserRoleChangedNotificationConverter.java
+++ b/src/main/java/io/knowledgeassets/myskills/server/communityuser/CommunityUserRoleChangedNotificationConverter.java
@@ -1,0 +1,15 @@
+package io.knowledgeassets.myskills.server.communityuser;
+
+import io.knowledgeassets.myskills.server.notification.AbstractNotificationResponse;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CommunityUserRoleChangedNotificationConverter implements Converter<CommunityUserRoleChangedNotification, AbstractNotificationResponse> {
+
+	@Override
+	public CommunityUserRoleChangedNotificationResponse convert(CommunityUserRoleChangedNotification notification) {
+		return CommunityUserRoleChangedNotificationResponse.of(notification);
+	}
+
+}

--- a/src/main/java/io/knowledgeassets/myskills/server/communityuser/CommunityUserRoleChangedNotificationResponse.java
+++ b/src/main/java/io/knowledgeassets/myskills/server/communityuser/CommunityUserRoleChangedNotificationResponse.java
@@ -1,0 +1,48 @@
+package io.knowledgeassets.myskills.server.communityuser;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import io.knowledgeassets.myskills.server.community.CommunityRole;
+import io.knowledgeassets.myskills.server.notification.AbstractNotificationResponse;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@ApiModel(
+		value = "CommunityUserRoleChangedNotificationResponse",
+		description = "This holds notification data about community user role changed event. " +
+				"It is used to transfer community user role changed notification data to a client."
+)
+@JsonTypeName("CommunityUserRoleChangedNotification")
+public class CommunityUserRoleChangedNotificationResponse extends AbstractNotificationResponse {
+
+	@ApiModelProperty("The new user role in a community.")
+	private CommunityRole role;
+
+	@ApiModelProperty("Community name.")
+	private String communityName;
+
+	@Builder
+	public CommunityUserRoleChangedNotificationResponse(String id, LocalDateTime creationDatetime, CommunityRole role, String communityName) {
+		super(id, creationDatetime);
+		this.role = role;
+		this.communityName = communityName;
+	}
+
+	public static CommunityUserRoleChangedNotificationResponse of(CommunityUserRoleChangedNotification notification) {
+		return CommunityUserRoleChangedNotificationResponse.builder()
+				.id(notification.getId())
+				.creationDatetime(notification.getCreationDatetime())
+				.role(notification.getRole())
+				.communityName(notification.getCommunityName())
+				.build();
+	}
+
+}

--- a/src/main/java/io/knowledgeassets/myskills/server/communityuser/UserKickedOutFromCommunityNotificationResponse.java
+++ b/src/main/java/io/knowledgeassets/myskills/server/communityuser/UserKickedOutFromCommunityNotificationResponse.java
@@ -20,7 +20,7 @@ import java.time.LocalDateTime;
 		description = "This holds notification data about user kicked out event. " +
 				"It is used to transfer user kicked out notification data to a client."
 )
-@JsonTypeName("UserKickedOutFromCommunityNotificationResponse")
+@JsonTypeName("UserKickedOutFromCommunityNotification")
 public class UserKickedOutFromCommunityNotificationResponse extends AbstractNotificationResponse {
 
 	@ApiModelProperty("The community user kicked from.")

--- a/src/main/java/io/knowledgeassets/myskills/server/communityuser/UserLeftCommunityNotificationResponse.java
+++ b/src/main/java/io/knowledgeassets/myskills/server/communityuser/UserLeftCommunityNotificationResponse.java
@@ -21,7 +21,7 @@ import java.time.LocalDateTime;
 		description = "This holds notification data about user left community event. " +
 				"It is used to transfer user left community notification data to a client."
 )
-@JsonTypeName("UserLeftCommunityNotificationResponse")
+@JsonTypeName("UserLeftCommunityNotification")
 public class UserLeftCommunityNotificationResponse extends AbstractNotificationResponse {
 
 	@ApiModelProperty("The community user kicked from.")

--- a/src/main/java/io/knowledgeassets/myskills/server/communityuser/registration/AcceptanceToCommunityNotificationResponse.java
+++ b/src/main/java/io/knowledgeassets/myskills/server/communityuser/registration/AcceptanceToCommunityNotificationResponse.java
@@ -19,7 +19,7 @@ import java.time.LocalDateTime;
 		description = "This holds notification data about user registration when a user was let to join a community." +
 				" It is used to transfer user registration notification data to a client."
 )
-@JsonTypeName("AcceptanceToCommunityNotificationResponse")
+@JsonTypeName("AcceptanceToCommunityNotification")
 public class AcceptanceToCommunityNotificationResponse extends AbstractNotificationResponse {
 
 	@ApiModelProperty("Registration the notification is associated with.")

--- a/src/main/java/io/knowledgeassets/myskills/server/communityuser/registration/InvitationToJoinCommunityNotificationResponse.java
+++ b/src/main/java/io/knowledgeassets/myskills/server/communityuser/registration/InvitationToJoinCommunityNotificationResponse.java
@@ -19,7 +19,7 @@ import java.time.LocalDateTime;
 		description = "This holds notification data about user registration when the user was invited to join a community. " +
 				"It is used to transfer user registration notification data to a client."
 )
-@JsonTypeName("InvitationToJoinCommunityNotificationResponse")
+@JsonTypeName("InvitationToJoinCommunityNotification")
 public class InvitationToJoinCommunityNotificationResponse extends AbstractNotificationResponse {
 
 	@ApiModelProperty("Registration the notification is associated with.")

--- a/src/main/java/io/knowledgeassets/myskills/server/communityuser/registration/RequestToJoinCommunityNotificationResponse.java
+++ b/src/main/java/io/knowledgeassets/myskills/server/communityuser/registration/RequestToJoinCommunityNotificationResponse.java
@@ -19,7 +19,7 @@ import java.time.LocalDateTime;
 		description = "This holds notification data about user registration when the user sent request to join a community. " +
 				" It is used to transfer user registration notification data to a client."
 )
-@JsonTypeName("RequestToJoinCommunityNotificationResponse")
+@JsonTypeName("RequestToJoinCommunityNotification")
 public class RequestToJoinCommunityNotificationResponse extends AbstractNotificationResponse {
 
 	@ApiModelProperty("Registration the notification is associated with.")

--- a/src/main/java/io/knowledgeassets/myskills/server/notification/NotificationRepository.java
+++ b/src/main/java/io/knowledgeassets/myskills/server/notification/NotificationRepository.java
@@ -19,6 +19,8 @@ public interface NotificationRepository extends Neo4jRepository<Notification, St
 			" WITH collect(n) AS notifications " +
 			" OPTIONAL MATCH (n:UserKickedOutFromCommunityNotification)-[:USER]->(:User {id: {userId}}) " +
 			" WITH notifications + collect(n) AS notifications " +
+			" OPTIONAL MATCH (n:CommunityUserRoleChangedNotification)-[:USER]->(:User {id: {userId}}) " +
+			" WITH notifications + collect(n) AS notifications " +
 			" OPTIONAL MATCH (n:CommunityDeletedNotification)-[:RECIPIENT]->(:User {id: {userId}}) " +
 			" WITH notifications + collect(n) AS notifications " +
 			" OPTIONAL MATCH (n:RequestToJoinCommunityNotification)-[:CAUSED_BY]->(registration:CommunityUserRegistration)-[:community]->(c:Community)<-[:COMMUNITY_USER {role:'MANAGER'}]-(:User {id: {userId}}) " +

--- a/src/test/java/io/knowledgeassets/myskills/server/communityuser/command/CommunityUserCommandServiceTests.java
+++ b/src/test/java/io/knowledgeassets/myskills/server/communityuser/command/CommunityUserCommandServiceTests.java
@@ -8,6 +8,7 @@ import io.knowledgeassets.myskills.server.communityuser.CommunityUserRepository;
 import io.knowledgeassets.myskills.server.exception.DuplicateResourceException;
 import io.knowledgeassets.myskills.server.exception.NoSuchResourceException;
 import io.knowledgeassets.myskills.server.notification.NotificationRepository;
+import io.knowledgeassets.myskills.server.notification.command.NotificationCommandService;
 import io.knowledgeassets.myskills.server.user.User;
 import org.hamcrest.core.AllOf;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,11 +41,14 @@ class CommunityUserCommandServiceTests {
 	@Mock
 	private NotificationRepository notificationRepository;
 
+	@Mock
+	private NotificationCommandService notificationCommandService;
+
 	private CommunityUserCommandService communityUserCommandService;
 
 	@BeforeEach
 	void setUp() {
-		this.communityUserCommandService = new CommunityUserCommandService(communityUserRepository, notificationRepository);
+		this.communityUserCommandService = new CommunityUserCommandService(communityUserRepository, notificationRepository, notificationCommandService);
 	}
 
 	@Test

--- a/src/test/java/io/knowledgeassets/myskills/server/notification/NotificationRepositoryTests.java
+++ b/src/test/java/io/knowledgeassets/myskills/server/notification/NotificationRepositoryTests.java
@@ -7,6 +7,7 @@ import io.knowledgeassets.myskills.server.community.CommunityRole;
 import io.knowledgeassets.myskills.server.community.CommunityType;
 import io.knowledgeassets.myskills.server.communityuser.CommunityUser;
 import io.knowledgeassets.myskills.server.communityuser.CommunityUserRepository;
+import io.knowledgeassets.myskills.server.communityuser.CommunityUserRoleChangedNotification;
 import io.knowledgeassets.myskills.server.communityuser.UserKickedOutFromCommunityNotification;
 import io.knowledgeassets.myskills.server.communityuser.UserLeftCommunityNotification;
 import io.knowledgeassets.myskills.server.communityuser.registration.CommunityUserRegistration;
@@ -162,6 +163,15 @@ class NotificationRepositoryTests {
 				.build()
 		);
 
+		notificationRepository.save(CommunityUserRoleChangedNotification.builder()
+				.id("yyy")
+				.role(CommunityRole.MANAGER)
+				.communityName("Community the role has been changed in.")
+				.creationDatetime(LocalDateTime.of(2018, 4, 3, 12, 0))
+				.user(communityManager)
+				.build()
+		);
+
 		notificationRepository.save(UserLeftCommunityNotification.builder()
 				.id("zyx")
 				.creationDatetime(LocalDateTime.of(2019, 3, 21, 15, 30))
@@ -183,7 +193,7 @@ class NotificationRepositoryTests {
 
 		final List<Notification> notifications = notificationRepository.getUserNotifications("123").collect(toList());
 
-		assertThat(notifications).hasSize(4);
+		assertThat(notifications).hasSize(5);
 		Notification notification = notifications.get(0);
 		assertThat(notification.getId()).isEqualTo("def");
 		assertThat(notification.getCreationDatetime()).isEqualTo(LocalDateTime.of(2019, 3, 26, 11, 0));
@@ -232,6 +242,15 @@ class NotificationRepositoryTests {
 		final CommunityDeletedNotification communityDeletedNotification = (CommunityDeletedNotification) notification;
 		assertThat(communityDeletedNotification.getCommunityName()).isEqualTo("Deleted community");
 		assertThat(communityDeletedNotification.getRecipients()).contains(communityManager);
+
+		notification = notifications.get(4);
+		assertThat(notification.getId()).isEqualTo("yyy");
+		assertThat(notification.getCreationDatetime()).isEqualTo(LocalDateTime.of(2018, 4, 3, 12, 0));
+		assertThat(notification).isInstanceOf(CommunityUserRoleChangedNotification.class);
+		final CommunityUserRoleChangedNotification communityUserRoleChangedNotification = (CommunityUserRoleChangedNotification) notification;
+		assertThat(communityUserRoleChangedNotification.getRole()).isEqualTo(CommunityRole.MANAGER);
+		assertThat(communityUserRoleChangedNotification.getCommunityName()).isEqualTo("Community the role has been changed in.");
+		assertThat(communityUserRoleChangedNotification.getUser()).isEqualTo(communityManager);
 	}
 
 	@DisplayName("Get notifications sent to the user.")
@@ -289,9 +308,18 @@ class NotificationRepositoryTests {
 				.build()
 		);
 
+		notificationRepository.save(CommunityUserRoleChangedNotification.builder()
+				.id("yyy")
+				.role(CommunityRole.MANAGER)
+				.communityName("Community the role has been changed in")
+				.creationDatetime(LocalDateTime.of(2018, 4, 3, 12, 0))
+				.user(commonUser)
+				.build()
+		);
+
 		final List<Notification> notifications = notificationRepository.getUserNotifications("123").collect(toList());
 
-		assertThat(notifications).hasSize(3);
+		assertThat(notifications).hasSize(4);
 
 		Notification notification = notifications.get(0);
 		assertThat(notification.getId()).isEqualTo("abc");
@@ -329,6 +357,15 @@ class NotificationRepositoryTests {
 		final CommunityDeletedNotification communityDeletedNotification = (CommunityDeletedNotification) notification;
 		assertThat(communityDeletedNotification.getCommunityName()).isEqualTo("Deleted community");
 		assertThat(communityDeletedNotification.getRecipients()).contains(commonUser);
+
+		notification = notifications.get(3);
+		assertThat(notification.getId()).isEqualTo("yyy");
+		assertThat(notification.getCreationDatetime()).isEqualTo(LocalDateTime.of(2018, 4, 3, 12, 0));
+		assertThat(notification).isInstanceOf(CommunityUserRoleChangedNotification.class);
+		final CommunityUserRoleChangedNotification communityUserRoleChangedNotification = (CommunityUserRoleChangedNotification) notification;
+		assertThat(communityUserRoleChangedNotification.getRole()).isEqualTo(CommunityRole.MANAGER);
+		assertThat(communityUserRoleChangedNotification.getCommunityName()).isEqualTo("Community the role has been changed in");
+		assertThat(communityUserRoleChangedNotification.getUser()).isEqualTo(commonUser);
 	}
 
 	@DisplayName("Get notifications sent to the communities the user is the manager of.")

--- a/src/test/java/io/knowledgeassets/myskills/server/notification/query/NotificationQueryServiceTests.java
+++ b/src/test/java/io/knowledgeassets/myskills/server/notification/query/NotificationQueryServiceTests.java
@@ -3,7 +3,9 @@ package io.knowledgeassets.myskills.server.notification.query;
 
 import io.knowledgeassets.myskills.server.community.Community;
 import io.knowledgeassets.myskills.server.community.CommunityDeletedNotification;
+import io.knowledgeassets.myskills.server.community.CommunityRole;
 import io.knowledgeassets.myskills.server.community.CommunityType;
+import io.knowledgeassets.myskills.server.communityuser.CommunityUserRoleChangedNotification;
 import io.knowledgeassets.myskills.server.communityuser.UserKickedOutFromCommunityNotification;
 import io.knowledgeassets.myskills.server.communityuser.UserLeftCommunityNotification;
 import io.knowledgeassets.myskills.server.communityuser.registration.CommunityUserRegistration;
@@ -114,6 +116,16 @@ class NotificationQueryServiceTests {
 								.id("abc")
 								.userName("tester")
 								.build()))
+						.build(),
+				CommunityUserRoleChangedNotification.builder()
+						.id("yyy")
+						.role(CommunityRole.MANAGER)
+						.communityName("Community the role has been changed in")
+						.creationDatetime(LocalDateTime.of(2018, 4, 3, 12, 0))
+						.user(User.builder()
+								.id("abc")
+								.userName("tester")
+								.build())
 						.build()
 		));
 
@@ -191,6 +203,16 @@ class NotificationQueryServiceTests {
 								.id("abc")
 								.userName("tester")
 								.build()))
+						.build(),
+				CommunityUserRoleChangedNotification.builder()
+						.id("yyy")
+						.role(CommunityRole.MANAGER)
+						.communityName("Community the role has been changed in")
+						.creationDatetime(LocalDateTime.of(2018, 4, 3, 12, 0))
+						.user(User.builder()
+								.id("abc")
+								.userName("tester")
+								.build())
 						.build()
 		);
 	}

--- a/src/test/java/io/knowledgeassets/myskills/server/user/notification/UserNotificationQueryControllerTests.java
+++ b/src/test/java/io/knowledgeassets/myskills/server/user/notification/UserNotificationQueryControllerTests.java
@@ -3,7 +3,9 @@ package io.knowledgeassets.myskills.server.user.notification;
 import io.knowledgeassets.myskills.server.common.AbstractControllerTests;
 import io.knowledgeassets.myskills.server.community.Community;
 import io.knowledgeassets.myskills.server.community.CommunityDeletedNotification;
+import io.knowledgeassets.myskills.server.community.CommunityRole;
 import io.knowledgeassets.myskills.server.community.CommunityType;
+import io.knowledgeassets.myskills.server.communityuser.CommunityUserRoleChangedNotification;
 import io.knowledgeassets.myskills.server.communityuser.UserKickedOutFromCommunityNotification;
 import io.knowledgeassets.myskills.server.communityuser.UserLeftCommunityNotification;
 import io.knowledgeassets.myskills.server.communityuser.registration.CommunityUserRegistration;
@@ -117,6 +119,13 @@ class UserNotificationQueryControllerTests extends AbstractControllerTests {
 						.creationDatetime(LocalDateTime.of(2019, 1, 3, 10, 0))
 						.communityName("Deleted community")
 						.recipients(singletonList(tester))
+						.build(),
+				CommunityUserRoleChangedNotification.builder()
+						.id("yyy")
+						.role(CommunityRole.MANAGER)
+						.communityName("Community the role has been changed in")
+						.creationDatetime(LocalDateTime.of(2018, 4, 3, 12, 0))
+						.user(tester)
 						.build()
 		));
 
@@ -125,9 +134,9 @@ class UserNotificationQueryControllerTests extends AbstractControllerTests {
 				.with(authentication(withUser(tester))))
 				.andExpect(status().isOk())
 				.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-				.andExpect(jsonPath("$.length()", is(equalTo(5))))
+				.andExpect(jsonPath("$.length()", is(equalTo(6))))
 				.andExpect(jsonPath("$[0].id", is(equalTo("123"))))
-				.andExpect(jsonPath("$[0].type", is(equalTo("InvitationToJoinCommunityNotificationResponse"))))
+				.andExpect(jsonPath("$[0].type", is(equalTo("InvitationToJoinCommunityNotification"))))
 				.andExpect(jsonPath("$[0].creationDatetime", is(equalTo("2019-03-27T09:34:00"))))
 				.andExpect(jsonPath("$[0].registration.approvedByUser", nullValue()))
 				.andExpect(jsonPath("$[0].registration.approvedByCommunity", is(equalTo(true))))
@@ -137,7 +146,7 @@ class UserNotificationQueryControllerTests extends AbstractControllerTests {
 				.andExpect(jsonPath("$[0].registration.community.type", is(equalTo("CLOSED"))))
 				.andExpect(jsonPath("$[0].registration.community.title", is(equalTo("Community"))))
 				.andExpect(jsonPath("$[1].id", is(equalTo("456"))))
-				.andExpect(jsonPath("$[1].type", is(equalTo("RequestToJoinCommunityNotificationResponse"))))
+				.andExpect(jsonPath("$[1].type", is(equalTo("RequestToJoinCommunityNotification"))))
 				.andExpect(jsonPath("$[1].creationDatetime", is(equalTo("2019-03-27T10:34:00"))))
 				.andExpect(jsonPath("$[1].registration.approvedByUser", is(equalTo(true))))
 				.andExpect(jsonPath("$[1].registration.approvedByCommunity", nullValue()))
@@ -147,13 +156,13 @@ class UserNotificationQueryControllerTests extends AbstractControllerTests {
 				.andExpect(jsonPath("$[1].registration.community.type", is(equalTo("CLOSED"))))
 				.andExpect(jsonPath("$[1].registration.community.title", is(equalTo("AnotherCommunity"))))
 				.andExpect(jsonPath("$[2].id", is(equalTo("789"))))
-				.andExpect(jsonPath("$[2].type", is(equalTo("UserKickedOutFromCommunityNotificationResponse"))))
+				.andExpect(jsonPath("$[2].type", is(equalTo("UserKickedOutFromCommunityNotification"))))
 				.andExpect(jsonPath("$[2].creationDatetime", is(equalTo("2019-03-25T10:00:00"))))
 				.andExpect(jsonPath("$[2].community.id", is(equalTo("773e8cce-fc06-4a62-a23e-58b52c097600"))))
 				.andExpect(jsonPath("$[2].community.title", is(equalTo("Community the user was kicked out from"))))
 				.andExpect(jsonPath("$[2].community.type", is(equalTo("CLOSED"))))
 				.andExpect(jsonPath("$[3].id", is(equalTo("901"))))
-				.andExpect(jsonPath("$[3].type", is(equalTo("UserLeftCommunityNotificationResponse"))))
+				.andExpect(jsonPath("$[3].type", is(equalTo("UserLeftCommunityNotification"))))
 				.andExpect(jsonPath("$[3].creationDatetime", is(equalTo("2019-03-21T15:30:00"))))
 				.andExpect(jsonPath("$[3].user.id", is(equalTo("fddd5bdd-8931-4eb6-a875-b52e10e07d35"))))
 				.andExpect(jsonPath("$[3].user.userName", is(equalTo("UserLeftCommunity"))))
@@ -161,9 +170,14 @@ class UserNotificationQueryControllerTests extends AbstractControllerTests {
 				.andExpect(jsonPath("$[3].community.title", is(equalTo("AnotherCommunity"))))
 				.andExpect(jsonPath("$[3].community.type", is(equalTo("CLOSED"))))
 				.andExpect(jsonPath("$[4].id", is(equalTo("902"))))
-				.andExpect(jsonPath("$[4].type", is(equalTo("CommunityDeletedNotificationResponse"))))
+				.andExpect(jsonPath("$[4].type", is(equalTo("CommunityDeletedNotification"))))
 				.andExpect(jsonPath("$[4].creationDatetime", is(equalTo("2019-01-03T10:00:00"))))
-				.andExpect(jsonPath("$[4].communityName", is(equalTo("Deleted community"))));
+				.andExpect(jsonPath("$[4].communityName", is(equalTo("Deleted community"))))
+				.andExpect(jsonPath("$[5].id", is(equalTo("yyy"))))
+				.andExpect(jsonPath("$[5].type", is(equalTo("CommunityUserRoleChangedNotification"))))
+				.andExpect(jsonPath("$[5].creationDatetime", is(equalTo("2018-04-03T12:00:00"))))
+				.andExpect(jsonPath("$[5].communityName", is(equalTo("Community the role has been changed in"))))
+				.andExpect(jsonPath("$[5].role", is(equalTo("MANAGER"))));
 	}
 
 	@DisplayName("Not authenticated user cannot get notifications.")


### PR DESCRIPTION
CommunityUserRoleChangedNotification is generated when role of a community user changes.

The type field of notification responses changed to have a value without "Response" suffix.

@svetivanova could you please take a look?