### PR TITLE
feature/community-name-field-for-notifications

### DIFF
--- a/src/main/java/com/tsmms/skoop/communityuser/UserKickedOutFromCommunityNotification.java
+++ b/src/main/java/com/tsmms/skoop/communityuser/UserKickedOutFromCommunityNotification.java
@@ -7,6 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.neo4j.ogm.annotation.Property;
 import org.neo4j.ogm.annotation.Relationship;
 
 import java.time.LocalDateTime;
@@ -21,10 +22,15 @@ public class UserKickedOutFromCommunityNotification extends Notification {
 	@Relationship(type = "COMMUNITY")
 	private Community community;
 
+	@Property(name = "communityName")
+	private String communityName;
+
 	@Builder
-	public UserKickedOutFromCommunityNotification(String id, LocalDateTime creationDatetime, User user, Community community) {
+	public UserKickedOutFromCommunityNotification(String id, LocalDateTime creationDatetime, User user, Community community,
+												  String communityName) {
 		super(id, creationDatetime);
 		this.user = user;
 		this.community = community;
+		this.communityName = communityName;
 	}
 }

--- a/src/main/java/com/tsmms/skoop/communityuser/UserKickedOutFromCommunityNotificationResponse.java
+++ b/src/main/java/com/tsmms/skoop/communityuser/UserKickedOutFromCommunityNotificationResponse.java
@@ -26,10 +26,15 @@ public class UserKickedOutFromCommunityNotificationResponse extends AbstractNoti
 	@ApiModelProperty("The community user kicked from.")
 	private CommunityResponse community;
 
+	@ApiModelProperty("Community name. It should be used by a client in case there is no reference to the community.")
+	private String communityName;
+
 	@Builder
-	public UserKickedOutFromCommunityNotificationResponse(String id, LocalDateTime creationDatetime, CommunityResponse community) {
+	public UserKickedOutFromCommunityNotificationResponse(String id, LocalDateTime creationDatetime, CommunityResponse community,
+														  String communityName) {
 		super(id, creationDatetime);
 		this.community = community;
+		this.communityName = communityName;
 	}
 
 	public static UserKickedOutFromCommunityNotificationResponse of(UserKickedOutFromCommunityNotification notification) {
@@ -37,6 +42,7 @@ public class UserKickedOutFromCommunityNotificationResponse extends AbstractNoti
 				.id(notification.getId())
 				.creationDatetime(notification.getCreationDatetime())
 				.community(CommunityResponse.of(notification.getCommunity()))
+				.communityName(notification.getCommunityName())
 				.build();
 	}
 

--- a/src/main/java/com/tsmms/skoop/communityuser/UserLeftCommunityNotification.java
+++ b/src/main/java/com/tsmms/skoop/communityuser/UserLeftCommunityNotification.java
@@ -7,6 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.neo4j.ogm.annotation.Property;
 import org.neo4j.ogm.annotation.Relationship;
 
 import java.time.LocalDateTime;
@@ -21,10 +22,15 @@ public class UserLeftCommunityNotification extends Notification {
 	@Relationship(type = "COMMUNITY")
 	private Community community;
 
+	@Property(name = "communityName")
+	private String communityName;
+
 	@Builder
-	public UserLeftCommunityNotification(String id, LocalDateTime creationDatetime, User user, Community community) {
+	public UserLeftCommunityNotification(String id, LocalDateTime creationDatetime, User user, Community community,
+										 String communityName) {
 		super(id, creationDatetime);
 		this.user = user;
 		this.community = community;
+		this.communityName = communityName;
 	}
 }

--- a/src/main/java/com/tsmms/skoop/communityuser/UserLeftCommunityNotificationResponse.java
+++ b/src/main/java/com/tsmms/skoop/communityuser/UserLeftCommunityNotificationResponse.java
@@ -30,11 +30,16 @@ public class UserLeftCommunityNotificationResponse extends AbstractNotificationR
 	@ApiModelProperty("User kicked out from a community.")
 	private UserSimpleResponse user;
 
+	@ApiModelProperty("Community name. It should be used by a client in case there is no reference to the community.")
+	private String communityName;
+
 	@Builder
-	public UserLeftCommunityNotificationResponse(String id, LocalDateTime creationDatetime, CommunityResponse community, UserSimpleResponse user) {
+	public UserLeftCommunityNotificationResponse(String id, LocalDateTime creationDatetime, CommunityResponse community, UserSimpleResponse user,
+												 String communityName) {
 		super(id, creationDatetime);
 		this.community = community;
 		this.user = user;
+		this.communityName = communityName;
 	}
 
 	public static UserLeftCommunityNotificationResponse of(UserLeftCommunityNotification notification) {
@@ -43,6 +48,7 @@ public class UserLeftCommunityNotificationResponse extends AbstractNotificationR
 				.creationDatetime(notification.getCreationDatetime())
 				.community(CommunityResponse.of(notification.getCommunity()))
 				.user(UserSimpleResponse.of(notification.getUser()))
+				.communityName(notification.getCommunityName())
 				.build();
 	}
 

--- a/src/main/java/com/tsmms/skoop/communityuser/command/CommunityUserCommandService.java
+++ b/src/main/java/com/tsmms/skoop/communityuser/command/CommunityUserCommandService.java
@@ -143,6 +143,7 @@ public class CommunityUserCommandService {
 				.creationDatetime(LocalDateTime.now())
 				.community(communityUser.getCommunity())
 				.user(communityUser.getUser())
+				.communityName(communityUser.getCommunity().getTitle())
 				.build()
 		);
 	}
@@ -160,6 +161,7 @@ public class CommunityUserCommandService {
 				.creationDatetime(LocalDateTime.now())
 				.community(communityUser.getCommunity())
 				.user(communityUser.getUser())
+				.communityName(communityUser.getCommunity().getTitle())
 				.build()
 		);
 	}

--- a/src/main/java/com/tsmms/skoop/communityuser/registration/AcceptanceToCommunityNotification.java
+++ b/src/main/java/com/tsmms/skoop/communityuser/registration/AcceptanceToCommunityNotification.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.neo4j.ogm.annotation.Property;
 import org.neo4j.ogm.annotation.Relationship;
 
 import java.time.LocalDateTime;
@@ -17,9 +18,14 @@ public class AcceptanceToCommunityNotification extends Notification {
 	@Relationship(type = "CAUSED_BY")
 	private CommunityUserRegistration registration;
 
+	@Property(name = "communityName")
+	private String communityName;
+
 	@Builder
-	public AcceptanceToCommunityNotification(String id, LocalDateTime creationDatetime, CommunityUserRegistration registration) {
+	public AcceptanceToCommunityNotification(String id, LocalDateTime creationDatetime, CommunityUserRegistration registration,
+											 String communityName) {
 		super(id, creationDatetime);
 		this.registration = registration;
+		this.communityName = communityName;
 	}
 }

--- a/src/main/java/com/tsmms/skoop/communityuser/registration/AcceptanceToCommunityNotificationResponse.java
+++ b/src/main/java/com/tsmms/skoop/communityuser/registration/AcceptanceToCommunityNotificationResponse.java
@@ -25,12 +25,17 @@ public class AcceptanceToCommunityNotificationResponse extends AbstractNotificat
 	@ApiModelProperty("Registration the notification is associated with.")
 	private CommunityUserRegistrationResponse registration;
 
+	@ApiModelProperty("Community name. It should be used by a client in case there is no reference to the community.")
+	private String communityName;
+
 	@Builder
 	public AcceptanceToCommunityNotificationResponse(String id,
 													 LocalDateTime creationDatetime,
-													 CommunityUserRegistrationResponse registration) {
+													 CommunityUserRegistrationResponse registration,
+													 String communityName) {
 		super(id, creationDatetime);
 		this.registration = registration;
+		this.communityName = communityName;
 	}
 
 	public static AcceptanceToCommunityNotificationResponse of(AcceptanceToCommunityNotification notification) {
@@ -38,6 +43,7 @@ public class AcceptanceToCommunityNotificationResponse extends AbstractNotificat
 				.id(notification.getId())
 				.creationDatetime(notification.getCreationDatetime())
 				.registration(CommunityUserRegistrationResponse.of(notification.getRegistration()))
+				.communityName(notification.getCommunityName())
 				.build();
 	}
 

--- a/src/main/java/com/tsmms/skoop/communityuser/registration/InvitationToJoinCommunityNotification.java
+++ b/src/main/java/com/tsmms/skoop/communityuser/registration/InvitationToJoinCommunityNotification.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.neo4j.ogm.annotation.Property;
 import org.neo4j.ogm.annotation.Relationship;
 
 import java.time.LocalDateTime;
@@ -17,9 +18,14 @@ public class InvitationToJoinCommunityNotification extends Notification {
 	@Relationship(type = "CAUSED_BY")
 	private CommunityUserRegistration registration;
 
+	@Property(name = "communityName")
+	private String communityName;
+
 	@Builder
-	public InvitationToJoinCommunityNotification(String id, LocalDateTime creationDatetime, CommunityUserRegistration registration) {
+	public InvitationToJoinCommunityNotification(String id, LocalDateTime creationDatetime, CommunityUserRegistration registration,
+												 String communityName) {
 		super(id, creationDatetime);
 		this.registration = registration;
+		this.communityName = communityName;
 	}
 }

--- a/src/main/java/com/tsmms/skoop/communityuser/registration/InvitationToJoinCommunityNotificationResponse.java
+++ b/src/main/java/com/tsmms/skoop/communityuser/registration/InvitationToJoinCommunityNotificationResponse.java
@@ -25,12 +25,17 @@ public class InvitationToJoinCommunityNotificationResponse extends AbstractNotif
 	@ApiModelProperty("Registration the notification is associated with.")
 	private CommunityUserRegistrationResponse registration;
 
+	@ApiModelProperty("Community name. It should be used by a client in case there is no reference to the community.")
+	private String communityName;
+
 	@Builder
 	public InvitationToJoinCommunityNotificationResponse(String id,
 														 LocalDateTime creationDatetime,
-														 CommunityUserRegistrationResponse registration) {
+														 CommunityUserRegistrationResponse registration,
+														 String communityName) {
 		super(id, creationDatetime);
 		this.registration = registration;
+		this.communityName = communityName;
 	}
 
 	public static InvitationToJoinCommunityNotificationResponse of(InvitationToJoinCommunityNotification notification) {
@@ -38,6 +43,7 @@ public class InvitationToJoinCommunityNotificationResponse extends AbstractNotif
 				.id(notification.getId())
 				.creationDatetime(notification.getCreationDatetime())
 				.registration(CommunityUserRegistrationResponse.of(notification.getRegistration()))
+				.communityName(notification.getCommunityName())
 				.build();
 	}
 

--- a/src/main/java/com/tsmms/skoop/communityuser/registration/RequestToJoinCommunityNotification.java
+++ b/src/main/java/com/tsmms/skoop/communityuser/registration/RequestToJoinCommunityNotification.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.neo4j.ogm.annotation.Property;
 import org.neo4j.ogm.annotation.Relationship;
 
 import java.time.LocalDateTime;
@@ -17,10 +18,15 @@ public class RequestToJoinCommunityNotification extends Notification {
 	@Relationship(type = "CAUSED_BY")
 	private CommunityUserRegistration registration;
 
+	@Property(name = "communityName")
+	private String communityName;
+
 	@Builder
-	public RequestToJoinCommunityNotification(String id, LocalDateTime creationDatetime, CommunityUserRegistration registration) {
+	public RequestToJoinCommunityNotification(String id, LocalDateTime creationDatetime, CommunityUserRegistration registration,
+											  String communityName) {
 		super(id, creationDatetime);
 		this.registration = registration;
+		this.communityName = communityName;
 	}
 
 }

--- a/src/main/java/com/tsmms/skoop/communityuser/registration/RequestToJoinCommunityNotificationResponse.java
+++ b/src/main/java/com/tsmms/skoop/communityuser/registration/RequestToJoinCommunityNotificationResponse.java
@@ -25,12 +25,17 @@ public class RequestToJoinCommunityNotificationResponse extends AbstractNotifica
 	@ApiModelProperty("Registration the notification is associated with.")
 	private CommunityUserRegistrationResponse registration;
 
+	@ApiModelProperty("Community name. It should be used by a client in case there is no reference to the community.")
+	private String communityName;
+
 	@Builder
 	public RequestToJoinCommunityNotificationResponse(String id,
 													  LocalDateTime creationDatetime,
-													  CommunityUserRegistrationResponse registration) {
+													  CommunityUserRegistrationResponse registration,
+													  String communityName) {
 		super(id, creationDatetime);
 		this.registration = registration;
+		this.communityName = communityName;
 	}
 
 	public static RequestToJoinCommunityNotificationResponse of(RequestToJoinCommunityNotification notification) {
@@ -38,6 +43,7 @@ public class RequestToJoinCommunityNotificationResponse extends AbstractNotifica
 				.id(notification.getId())
 				.creationDatetime(notification.getCreationDatetime())
 				.registration(CommunityUserRegistrationResponse.of(notification.getRegistration()))
+				.communityName(notification.getCommunityName())
 				.build();
 	}
 

--- a/src/main/java/com/tsmms/skoop/communityuser/registration/command/CommunityUserRegistrationCommandService.java
+++ b/src/main/java/com/tsmms/skoop/communityuser/registration/command/CommunityUserRegistrationCommandService.java
@@ -68,6 +68,7 @@ public class CommunityUserRegistrationCommandService {
 					.id(UUID.randomUUID().toString())
 					.creationDatetime(LocalDateTime.now())
 					.registration(communityUserRegistration)
+					.communityName(communityUserRegistration.getCommunity().getTitle())
 					.build()
 			);
 		}
@@ -101,6 +102,7 @@ public class CommunityUserRegistrationCommandService {
 				.id(UUID.randomUUID().toString())
 				.registration(registration)
 				.creationDatetime(LocalDateTime.now())
+				.communityName(registration.getCommunity().getTitle())
 				.build()
 		).forEach(notificationCommandService::save);
 		return registrations;
@@ -132,6 +134,7 @@ public class CommunityUserRegistrationCommandService {
 		notificationCommandService.save(RequestToJoinCommunityNotification.builder()
 				.id(UUID.randomUUID().toString())
 				.registration(registration)
+				.communityName(registration.getCommunity().getTitle())
 				.creationDatetime(LocalDateTime.now())
 				.build()
 		);

--- a/src/test/java/com/tsmms/skoop/notification/NotificationRepositoryTests.java
+++ b/src/test/java/com/tsmms/skoop/notification/NotificationRepositoryTests.java
@@ -144,6 +144,7 @@ class NotificationRepositoryTests {
 				.id("abc")
 				.creationDatetime(LocalDateTime.of(2019, 3, 26, 10, 0))
 				.registration(firstRegistration)
+				.communityName("Java User Group")
 				.build());
 
 		// notification that commonUser sent request to join "JavaScript User Group". It will be shown to communityManager.
@@ -152,6 +153,7 @@ class NotificationRepositoryTests {
 				.id("def")
 				.creationDatetime(LocalDateTime.of(2019, 3, 26, 11, 0))
 				.registration(secondRegistration)
+				.communityName("JavaScript User Group")
 				.build()
 		);
 
@@ -161,6 +163,7 @@ class NotificationRepositoryTests {
 				.id("ghi")
 				.creationDatetime(LocalDateTime.of(2019, 3, 27, 11, 0))
 				.registration(thirdRegistration)
+				.communityName("Frontend developers")
 				.build()
 		);
 
@@ -181,6 +184,7 @@ class NotificationRepositoryTests {
 						.id("0123")
 						.userName("UserLeftCommunity")
 						.build())
+				.communityName("JavaScript User Group")
 				.build()
 		);
 
@@ -207,6 +211,7 @@ class NotificationRepositoryTests {
 		assertThat(requestToJoinCommunityNotification.getRegistration().getRegisteredUser()).isEqualTo(commonUser);
 		assertThat(requestToJoinCommunityNotification.getRegistration().getId()).isEqualTo("123456");
 		assertThat(requestToJoinCommunityNotification.getRegistration().getCreationDatetime()).isEqualTo(LocalDateTime.of(2019, 3, 26, 11, 0));
+		assertThat(requestToJoinCommunityNotification.getCommunityName()).isEqualTo("JavaScript User Group");
 
 		notification = notifications.get(1);
 		assertThat(notification.getId()).isEqualTo("abc");
@@ -224,6 +229,7 @@ class NotificationRepositoryTests {
 		assertThat(invitationToJoinCommunityNotification.getRegistration().getRegisteredUser()).isEqualTo(communityManager);
 		assertThat(invitationToJoinCommunityNotification.getRegistration().getId()).isEqualTo("654321");
 		assertThat(invitationToJoinCommunityNotification.getRegistration().getCreationDatetime()).isEqualTo(LocalDateTime.of(2019, 3, 26, 10, 0));
+		assertThat(invitationToJoinCommunityNotification.getCommunityName()).isEqualTo("Java User Group");
 
 		notification = notifications.get(2);
 		assertThat(notification.getId()).isEqualTo("zyx");
@@ -235,6 +241,7 @@ class NotificationRepositoryTests {
 				.id("0123")
 				.userName("UserLeftCommunity")
 				.build());
+		assertThat(userLeftCommunityNotification.getCommunityName()).isEqualTo("JavaScript User Group");
 
 		notification = notifications.get(3);
 		assertThat(notification.getId()).isEqualTo("iop");
@@ -286,6 +293,7 @@ class NotificationRepositoryTests {
 				.id("abc")
 				.creationDatetime(LocalDateTime.of(2019, 3, 26, 10, 0))
 				.registration(firstRegistration)
+				.communityName("Java User Group")
 				.build());
 
 		notificationRepository.save(UserKickedOutFromCommunityNotification.builder()
@@ -298,6 +306,7 @@ class NotificationRepositoryTests {
 						.type(CommunityType.CLOSED)
 						.build()
 				)
+				.communityName("JavaScript User Group")
 				.build()
 		);
 
@@ -338,6 +347,7 @@ class NotificationRepositoryTests {
 		assertThat(invitationToJoinCommunityNotification.getRegistration().getRegisteredUser()).isEqualTo(commonUser);
 		assertThat(invitationToJoinCommunityNotification.getRegistration().getId()).isEqualTo("654321");
 		assertThat(invitationToJoinCommunityNotification.getRegistration().getCreationDatetime()).isEqualTo(LocalDateTime.of(2019, 3, 26, 10, 0));
+		assertThat(invitationToJoinCommunityNotification.getCommunityName()).isEqualTo("Java User Group");
 
 		notification = notifications.get(1);
 		assertThat(notification.getId()).isEqualTo("def");
@@ -350,6 +360,7 @@ class NotificationRepositoryTests {
 				.title("JavaScript User Group")
 				.type(CommunityType.CLOSED)
 				.build());
+		assertThat(userKickedOutFromCommunityNotification.getCommunityName()).isEqualTo("JavaScript User Group");
 
 		notification = notifications.get(2);
 		assertThat(notification.getId()).isEqualTo("iop");
@@ -419,6 +430,7 @@ class NotificationRepositoryTests {
 				.id("def")
 				.creationDatetime(LocalDateTime.of(2019, 3, 26, 11, 0))
 				.registration(firstRegistration)
+				.communityName("JavaScript User Group")
 				.build()
 		);
 
@@ -437,6 +449,7 @@ class NotificationRepositoryTests {
 		assertThat(requestToJoinCommunityNotification.getRegistration().getRegisteredUser()).isEqualTo(commonUser);
 		assertThat(requestToJoinCommunityNotification.getRegistration().getId()).isEqualTo("123456");
 		assertThat(requestToJoinCommunityNotification.getRegistration().getCreationDatetime()).isEqualTo(LocalDateTime.of(2019, 3, 26, 11, 0));
+		assertThat(requestToJoinCommunityNotification.getCommunityName()).isEqualTo("JavaScript User Group");
 	}
 
 }

--- a/src/test/java/com/tsmms/skoop/notification/command/NotificationCommandServiceTests.java
+++ b/src/test/java/com/tsmms/skoop/notification/command/NotificationCommandServiceTests.java
@@ -52,6 +52,7 @@ class NotificationCommandServiceTests {
 								.build()
 						)
 						.build())
+				.communityName("Community")
 				.build()
 		)).willReturn(InvitationToJoinCommunityNotification.builder()
 				.id("123")
@@ -70,6 +71,7 @@ class NotificationCommandServiceTests {
 								.build()
 						)
 						.build())
+				.communityName("Community")
 				.build());
 
 		final Notification notification = this.notificationCommandService.save(InvitationToJoinCommunityNotification.builder()
@@ -89,6 +91,7 @@ class NotificationCommandServiceTests {
 								.build()
 						)
 						.build())
+				.communityName("Community")
 				.build());
 
 		assertThat(notification.getId()).isEqualTo("123");
@@ -102,6 +105,7 @@ class NotificationCommandServiceTests {
 		assertThat(invitationToJoinCommunityNotification.getRegistration().getCommunity().getId()).isEqualTo("cba");
 		assertThat(invitationToJoinCommunityNotification.getRegistration().getCommunity().getType()).isEqualTo(CommunityType.CLOSED);
 		assertThat(invitationToJoinCommunityNotification.getRegistration().getCommunity().getTitle()).isEqualTo("Community");
+		assertThat(invitationToJoinCommunityNotification.getCommunityName()).isEqualTo("Community");
 	}
 
 }

--- a/src/test/java/com/tsmms/skoop/notification/query/NotificationQueryServiceTests.java
+++ b/src/test/java/com/tsmms/skoop/notification/query/NotificationQueryServiceTests.java
@@ -62,6 +62,7 @@ class NotificationQueryServiceTests {
 										.build()
 								)
 								.build())
+						.communityName("Community")
 						.build(),
 				RequestToJoinCommunityNotification.builder()
 						.id("456")
@@ -80,6 +81,7 @@ class NotificationQueryServiceTests {
 										.build()
 								)
 								.build())
+						.communityName("AnotherCommunity")
 						.build(),
 				UserKickedOutFromCommunityNotification.builder()
 						.id("def")
@@ -94,6 +96,7 @@ class NotificationQueryServiceTests {
 								.type(CommunityType.CLOSED)
 								.build()
 						)
+						.communityName("JavaScript User Group")
 						.build(),
 				UserLeftCommunityNotification.builder()
 						.id("zyx")
@@ -107,6 +110,7 @@ class NotificationQueryServiceTests {
 								.id("0123")
 								.userName("UserLeftCommunity")
 								.build())
+						.communityName("AnotherCommunity")
 						.build(),
 				CommunityDeletedNotification.builder()
 						.id("iop")
@@ -149,6 +153,7 @@ class NotificationQueryServiceTests {
 										.build()
 								)
 								.build())
+						.communityName("Community")
 						.build(),
 				RequestToJoinCommunityNotification.builder()
 						.id("456")
@@ -167,6 +172,7 @@ class NotificationQueryServiceTests {
 										.build()
 								)
 								.build())
+						.communityName("AnotherCommunity")
 						.build(),
 				UserKickedOutFromCommunityNotification.builder()
 						.id("def")
@@ -181,6 +187,7 @@ class NotificationQueryServiceTests {
 								.type(CommunityType.CLOSED)
 								.build()
 						)
+						.communityName("JavaScript User Group")
 						.build(),
 				UserLeftCommunityNotification.builder()
 						.id("zyx")
@@ -194,6 +201,7 @@ class NotificationQueryServiceTests {
 								.id("0123")
 								.userName("UserLeftCommunity")
 								.build())
+						.communityName("AnotherCommunity")
 						.build(),
 				CommunityDeletedNotification.builder()
 						.id("iop")

--- a/src/test/java/com/tsmms/skoop/user/notification/UserNotificationQueryControllerTests.java
+++ b/src/test/java/com/tsmms/skoop/user/notification/UserNotificationQueryControllerTests.java
@@ -9,6 +9,7 @@ import com.tsmms.skoop.community.CommunityType;
 import com.tsmms.skoop.communityuser.CommunityUserRoleChangedNotification;
 import com.tsmms.skoop.communityuser.UserKickedOutFromCommunityNotification;
 import com.tsmms.skoop.communityuser.UserLeftCommunityNotification;
+import com.tsmms.skoop.communityuser.registration.AcceptanceToCommunityNotification;
 import com.tsmms.skoop.communityuser.registration.CommunityUserRegistration;
 import com.tsmms.skoop.communityuser.registration.InvitationToJoinCommunityNotification;
 import com.tsmms.skoop.communityuser.registration.RequestToJoinCommunityNotification;
@@ -71,6 +72,7 @@ class UserNotificationQueryControllerTests extends AbstractControllerTests {
 										.build()
 								)
 								.build())
+						.communityName("Community")
 						.build(),
 				RequestToJoinCommunityNotification.builder()
 						.id("456")
@@ -89,6 +91,7 @@ class UserNotificationQueryControllerTests extends AbstractControllerTests {
 										.build()
 								)
 								.build())
+						.communityName("AnotherCommunity")
 						.build(),
 				UserKickedOutFromCommunityNotification.builder()
 						.id("789")
@@ -100,6 +103,7 @@ class UserNotificationQueryControllerTests extends AbstractControllerTests {
 								.type(CommunityType.CLOSED)
 								.build()
 						)
+						.communityName("Community the user was kicked out from")
 						.build(),
 				UserLeftCommunityNotification.builder()
 						.id("901")
@@ -113,6 +117,7 @@ class UserNotificationQueryControllerTests extends AbstractControllerTests {
 								.id("fddd5bdd-8931-4eb6-a875-b52e10e07d35")
 								.userName("UserLeftCommunity")
 								.build())
+						.communityName("AnotherCommunity")
 						.build(),
 				CommunityDeletedNotification.builder()
 						.id("902")
@@ -126,6 +131,25 @@ class UserNotificationQueryControllerTests extends AbstractControllerTests {
 						.communityName("Community the role has been changed in")
 						.creationDatetime(LocalDateTime.of(2018, 4, 3, 12, 0))
 						.user(tester)
+						.build(),
+				AcceptanceToCommunityNotification.builder()
+						.communityName("Community the user was accepted in")
+						.creationDatetime(LocalDateTime.of(2018, 4, 3, 12, 0))
+						.id("zzz")
+						.registration(CommunityUserRegistration.builder()
+								.approvedByUser(true)
+								.approvedByCommunity(true)
+								.registeredUser(User.builder()
+										.id("56ef4778-a084-4509-9a3e-80b7895cf7b0")
+										.userName("tester")
+										.build())
+								.community(Community.builder()
+										.id("999913dc-a10d-4c85-8613-abe0fa0cf210")
+										.type(CommunityType.CLOSED)
+										.title("Community the user was accepted in")
+										.build()
+								)
+								.build())
 						.build()
 		));
 
@@ -134,7 +158,7 @@ class UserNotificationQueryControllerTests extends AbstractControllerTests {
 				.with(authentication(JwtAuthenticationFactory.withUser(tester))))
 				.andExpect(status().isOk())
 				.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-				.andExpect(jsonPath("$.length()", is(equalTo(6))))
+				.andExpect(jsonPath("$.length()", is(equalTo(7))))
 				.andExpect(jsonPath("$[0].id", is(equalTo("123"))))
 				.andExpect(jsonPath("$[0].type", is(equalTo("InvitationToJoinCommunityNotification"))))
 				.andExpect(jsonPath("$[0].creationDatetime", is(equalTo("2019-03-27T09:34:00"))))
@@ -145,6 +169,7 @@ class UserNotificationQueryControllerTests extends AbstractControllerTests {
 				.andExpect(jsonPath("$[0].registration.community.id", is(equalTo("836713dc-a10d-4c85-8613-abe0fa0cf210"))))
 				.andExpect(jsonPath("$[0].registration.community.type", is(equalTo("CLOSED"))))
 				.andExpect(jsonPath("$[0].registration.community.title", is(equalTo("Community"))))
+				.andExpect(jsonPath("$[0].communityName", is(equalTo("Community"))))
 				.andExpect(jsonPath("$[1].id", is(equalTo("456"))))
 				.andExpect(jsonPath("$[1].type", is(equalTo("RequestToJoinCommunityNotification"))))
 				.andExpect(jsonPath("$[1].creationDatetime", is(equalTo("2019-03-27T10:34:00"))))
@@ -155,12 +180,14 @@ class UserNotificationQueryControllerTests extends AbstractControllerTests {
 				.andExpect(jsonPath("$[1].registration.community.id", is(equalTo("7d616eaa-8a09-420a-b4f2-99b74b360308"))))
 				.andExpect(jsonPath("$[1].registration.community.type", is(equalTo("CLOSED"))))
 				.andExpect(jsonPath("$[1].registration.community.title", is(equalTo("AnotherCommunity"))))
+				.andExpect(jsonPath("$[1].communityName", is(equalTo("AnotherCommunity"))))
 				.andExpect(jsonPath("$[2].id", is(equalTo("789"))))
 				.andExpect(jsonPath("$[2].type", is(equalTo("UserKickedOutFromCommunityNotification"))))
 				.andExpect(jsonPath("$[2].creationDatetime", is(equalTo("2019-03-25T10:00:00"))))
 				.andExpect(jsonPath("$[2].community.id", is(equalTo("773e8cce-fc06-4a62-a23e-58b52c097600"))))
 				.andExpect(jsonPath("$[2].community.title", is(equalTo("Community the user was kicked out from"))))
 				.andExpect(jsonPath("$[2].community.type", is(equalTo("CLOSED"))))
+				.andExpect(jsonPath("$[2].communityName", is(equalTo("Community the user was kicked out from"))))
 				.andExpect(jsonPath("$[3].id", is(equalTo("901"))))
 				.andExpect(jsonPath("$[3].type", is(equalTo("UserLeftCommunityNotification"))))
 				.andExpect(jsonPath("$[3].creationDatetime", is(equalTo("2019-03-21T15:30:00"))))
@@ -169,6 +196,7 @@ class UserNotificationQueryControllerTests extends AbstractControllerTests {
 				.andExpect(jsonPath("$[3].community.id", is(equalTo("7d616eaa-8a09-420a-b4f2-99b74b360308"))))
 				.andExpect(jsonPath("$[3].community.title", is(equalTo("AnotherCommunity"))))
 				.andExpect(jsonPath("$[3].community.type", is(equalTo("CLOSED"))))
+				.andExpect(jsonPath("$[3].communityName", is(equalTo("AnotherCommunity"))))
 				.andExpect(jsonPath("$[4].id", is(equalTo("902"))))
 				.andExpect(jsonPath("$[4].type", is(equalTo("CommunityDeletedNotification"))))
 				.andExpect(jsonPath("$[4].creationDatetime", is(equalTo("2019-01-03T10:00:00"))))
@@ -177,7 +205,18 @@ class UserNotificationQueryControllerTests extends AbstractControllerTests {
 				.andExpect(jsonPath("$[5].type", is(equalTo("CommunityUserRoleChangedNotification"))))
 				.andExpect(jsonPath("$[5].creationDatetime", is(equalTo("2018-04-03T12:00:00"))))
 				.andExpect(jsonPath("$[5].communityName", is(equalTo("Community the role has been changed in"))))
-				.andExpect(jsonPath("$[5].role", is(equalTo("MANAGER"))));
+				.andExpect(jsonPath("$[5].role", is(equalTo("MANAGER"))))
+				.andExpect(jsonPath("$[6].id", is(equalTo("zzz"))))
+				.andExpect(jsonPath("$[6].type", is(equalTo("AcceptanceToCommunityNotification"))))
+				.andExpect(jsonPath("$[6].creationDatetime", is(equalTo("2018-04-03T12:00:00"))))
+				.andExpect(jsonPath("$[6].communityName", is(equalTo("Community the user was accepted in"))))
+				.andExpect(jsonPath("$[6].registration.approvedByUser", is(equalTo(true))))
+				.andExpect(jsonPath("$[6].registration.approvedByCommunity", is(equalTo(true))))
+				.andExpect(jsonPath("$[6].registration.user.id", is(equalTo("56ef4778-a084-4509-9a3e-80b7895cf7b0"))))
+				.andExpect(jsonPath("$[6].registration.user.userName", is(equalTo("tester"))))
+				.andExpect(jsonPath("$[6].registration.community.id", is(equalTo("999913dc-a10d-4c85-8613-abe0fa0cf210"))))
+				.andExpect(jsonPath("$[6].registration.community.type", is(equalTo("CLOSED"))))
+				.andExpect(jsonPath("$[6].registration.community.title", is(equalTo("Community the user was accepted in"))));
 	}
 
 	@DisplayName("Not authenticated user cannot get notifications.")


### PR DESCRIPTION
The field "communityName" introduced for the notifications to provide name of the community in case the community was deleted.
@svetivanova could you please take a look?