### PR TITLE
feature/community-deleted-notification-to-users-with-pending-requests-to-join

### DIFF
--- a/src/main/java/com/tsmms/skoop/communityuser/registration/CommunityUserRegistrationRepository.java
+++ b/src/main/java/com/tsmms/skoop/communityuser/registration/CommunityUserRegistrationRepository.java
@@ -4,10 +4,15 @@ import org.springframework.data.neo4j.repository.Neo4jRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
+import java.util.stream.Stream;
 
 @Repository
 public interface CommunityUserRegistrationRepository extends Neo4jRepository<CommunityUserRegistration, String> {
 
 	Optional<CommunityUserRegistration> findByRegisteredUserIdAndCommunityIdAndApprovedByUserIsTrueAndApprovedByCommunityIsNull(String registeredUserId, String communityId);
+
+	Stream<CommunityUserRegistration> findByCommunityIdAndApprovedByUserIsTrueAndApprovedByCommunityIsNull(String communityId);
+
+	Stream<CommunityUserRegistration> findByCommunityIdAndApprovedByUserIsNullAndApprovedByCommunityIsTrue(String communityId);
 
 }

--- a/src/main/java/com/tsmms/skoop/communityuser/registration/command/CommunityUserRegistrationCommandService.java
+++ b/src/main/java/com/tsmms/skoop/communityuser/registration/command/CommunityUserRegistrationCommandService.java
@@ -16,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
 
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -139,6 +140,16 @@ public class CommunityUserRegistrationCommandService {
 				.build()
 		);
 		return registration;
+	}
+
+	@Transactional
+	public void delete(Collection<CommunityUserRegistration> communityUserRegistrations) {
+		if (communityUserRegistrations == null) {
+			throw new IllegalArgumentException("The collection with community user registrations cannot be null.");
+		}
+		if (!communityUserRegistrations.isEmpty()) {
+			communityUserRegistrationRepository.deleteAll(communityUserRegistrations);
+		}
 	}
 
 }

--- a/src/main/java/com/tsmms/skoop/communityuser/registration/query/CommunityUserRegistrationQueryService.java
+++ b/src/main/java/com/tsmms/skoop/communityuser/registration/query/CommunityUserRegistrationQueryService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
+import java.util.stream.Stream;
 
 @Service
 public class CommunityUserRegistrationQueryService {
@@ -25,6 +26,22 @@ public class CommunityUserRegistrationQueryService {
 	public Optional<CommunityUserRegistration> getPendingUserRequestToJoinCommunity(String userId, String communityId) {
 		return communityUserRegistrationRepository
 				.findByRegisteredUserIdAndCommunityIdAndApprovedByUserIsTrueAndApprovedByCommunityIsNull(userId, communityId);
+	}
+
+	@Transactional(readOnly = true)
+	public Stream<CommunityUserRegistration> getPendingUserRequestsToJoinCommunity(String communityId) {
+		if (communityId == null) {
+			throw new IllegalArgumentException("Community ID cannot be null.");
+		}
+		return communityUserRegistrationRepository.findByCommunityIdAndApprovedByUserIsTrueAndApprovedByCommunityIsNull(communityId);
+	}
+
+	@Transactional(readOnly = true)
+	public Stream<CommunityUserRegistration> getPendingInvitationsToJoinCommunity(String communityId) {
+		if (communityId == null) {
+			throw new IllegalArgumentException("Community ID cannot be null.");
+		}
+		return communityUserRegistrationRepository.findByCommunityIdAndApprovedByUserIsNullAndApprovedByCommunityIsTrue(communityId);
 	}
 
 }

--- a/src/test/java/com/tsmms/skoop/community/command/CommunityCommandServiceTests.java
+++ b/src/test/java/com/tsmms/skoop/community/command/CommunityCommandServiceTests.java
@@ -6,6 +6,7 @@ import com.tsmms.skoop.community.CommunityRole;
 import com.tsmms.skoop.community.CommunityType;
 import com.tsmms.skoop.community.link.Link;
 import com.tsmms.skoop.community.link.command.LinkCommandService;
+import com.tsmms.skoop.communityuser.registration.query.CommunityUserRegistrationQueryService;
 import com.tsmms.skoop.exception.DuplicateResourceException;
 import com.tsmms.skoop.exception.NoSuchResourceException;
 import com.tsmms.skoop.security.CurrentUserService;
@@ -71,6 +72,9 @@ class CommunityCommandServiceTests {
 	@Mock
 	private LinkCommandService linkCommandService;
 
+	@Mock
+	private CommunityUserRegistrationQueryService communityUserRegistrationQueryService;
+
 	private CommunityCommandService communityCommandService;
 
 	@BeforeEach
@@ -82,7 +86,8 @@ class CommunityCommandServiceTests {
 				communityUserCommandService,
 				communityUserQueryService,
 				notificationCommandService,
-				linkCommandService);
+				linkCommandService,
+				communityUserRegistrationQueryService);
 	}
 
 	@Test

--- a/src/test/java/com/tsmms/skoop/communityuser/registration/CommunityUserRegistrationRepositoryTests.java
+++ b/src/test/java/com/tsmms/skoop/communityuser/registration/CommunityUserRegistrationRepositoryTests.java
@@ -12,7 +12,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.neo4j.DataNeo4jTest;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -60,6 +63,100 @@ class CommunityUserRegistrationRepositoryTests {
 		Assertions.assertThat(registrationOptional).isNotEmpty();
 		CommunityUserRegistration registration = registrationOptional.get();
 		assertThat(registration.getId()).isEqualTo("abc");
+	}
+
+	@DisplayName("Finds community user registrations for the specified community approved by community and still not approved by the user.")
+	@Test
+	void findsByCommunityIdAndApprovedByUserIsNullAndApprovedByCommunityIsTrue() {
+
+		Community community = communityRepository.save(Community.builder()
+				.id("123")
+				.title("Java User Group")
+				.type(CommunityType.CLOSED)
+				.build()
+		);
+
+		User user = userRepository.save(User.builder()
+				.id("db87d46a-e4ca-451a-903b-e8533e0b924b")
+				.userName("tester")
+				.build());
+
+		communityUserRegistrationRepository.save(CommunityUserRegistration.builder()
+				.registeredUser(user)
+				.community(community)
+				.approvedByUser(null)
+				.approvedByCommunity(true)
+				.creationDatetime(LocalDateTime.of(2019, 2, 20, 20, 0))
+				.id("abc")
+				.build()
+		);
+
+		communityUserRegistrationRepository.save(CommunityUserRegistration.builder()
+				.registeredUser(user)
+				.community(community)
+				.approvedByUser(true)
+				.approvedByCommunity(true)
+				.creationDatetime(LocalDateTime.of(2019, 2, 20, 20, 0))
+				.id("def")
+				.build()
+		);
+
+		final Stream<CommunityUserRegistration> communityUserRegistrationStream = communityUserRegistrationRepository.findByCommunityIdAndApprovedByUserIsNullAndApprovedByCommunityIsTrue("123");
+		final List<CommunityUserRegistration> communityUserRegistrations = communityUserRegistrationStream.collect(Collectors.toList());
+		assertThat(communityUserRegistrations).hasSize(1);
+		assertThat(communityUserRegistrations.get(0).getId()).isEqualTo("abc");
+		assertThat(communityUserRegistrations.get(0).getApprovedByCommunity()).isTrue();
+		assertThat(communityUserRegistrations.get(0).getApprovedByUser()).isNull();
+		assertThat(communityUserRegistrations.get(0).getCommunity()).isEqualTo(community);
+		assertThat(communityUserRegistrations.get(0).getRegisteredUser()).isEqualTo(user);
+		assertThat(communityUserRegistrations.get(0).getCreationDatetime()).isEqualTo(LocalDateTime.of(2019, 2, 20, 20, 0));
+	}
+
+	@DisplayName("Finds community user registrations for the specified community approved by user and still not approved by the community.")
+	@Test
+	void findByCommunityIdAndApprovedByUserIsTrueAndApprovedByCommunityIsNull() {
+
+		Community community = communityRepository.save(Community.builder()
+				.id("123")
+				.title("Java User Group")
+				.type(CommunityType.CLOSED)
+				.build()
+		);
+
+		User user = userRepository.save(User.builder()
+				.id("db87d46a-e4ca-451a-903b-e8533e0b924b")
+				.userName("tester")
+				.build());
+
+		communityUserRegistrationRepository.save(CommunityUserRegistration.builder()
+				.registeredUser(user)
+				.community(community)
+				.approvedByUser(true)
+				.approvedByCommunity(null)
+				.creationDatetime(LocalDateTime.of(2019, 2, 20, 20, 0))
+				.id("abc")
+				.build()
+		);
+
+		communityUserRegistrationRepository.save(CommunityUserRegistration.builder()
+				.registeredUser(user)
+				.community(community)
+				.approvedByUser(true)
+				.approvedByCommunity(true)
+				.creationDatetime(LocalDateTime.of(2019, 2, 20, 20, 0))
+				.id("def")
+				.build()
+		);
+
+		final Stream<CommunityUserRegistration> communityUserRegistrationStream = communityUserRegistrationRepository.findByCommunityIdAndApprovedByUserIsTrueAndApprovedByCommunityIsNull("123");
+		final List<CommunityUserRegistration> communityUserRegistrations = communityUserRegistrationStream.collect(Collectors.toList());
+		assertThat(communityUserRegistrations).hasSize(1);
+		assertThat(communityUserRegistrations.get(0).getId()).isEqualTo("abc");
+		assertThat(communityUserRegistrations.get(0).getApprovedByCommunity()).isNull();
+		assertThat(communityUserRegistrations.get(0).getApprovedByUser()).isTrue();
+		assertThat(communityUserRegistrations.get(0).getCommunity()).isEqualTo(community);
+		assertThat(communityUserRegistrations.get(0).getRegisteredUser()).isEqualTo(user);
+		assertThat(communityUserRegistrations.get(0).getCreationDatetime()).isEqualTo(LocalDateTime.of(2019, 2, 20, 20, 0));
 	}
 
 }

--- a/src/test/java/com/tsmms/skoop/communityuser/registration/command/CommunityUserRegistrationCommandServiceTests.java
+++ b/src/test/java/com/tsmms/skoop/communityuser/registration/command/CommunityUserRegistrationCommandServiceTests.java
@@ -28,6 +28,7 @@ import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.isA;
 import static org.hamcrest.core.AllOf.allOf;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.hamcrest.MockitoHamcrest.argThat;
@@ -492,6 +493,33 @@ class CommunityUserRegistrationCommandServiceTests {
 						.approvedByCommunity(null)
 						.build()
 		));
+	}
+
+	@DisplayName("Deletes community user registrations.")
+	@Test
+	void deletesCommunityUserRegistrations() {
+		assertDoesNotThrow(() -> communityUserRegistrationCommandService.delete(Arrays.asList(CommunityUserRegistration.builder()
+				.approvedByCommunity(null)
+				.approvedByUser(true)
+				.registeredUser(User.builder()
+						.id("db87d46a-e4ca-451a-903b-e8533e0b924b")
+						.userName("tester")
+						.build())
+				.community(Community.builder()
+						.id("123")
+						.title("Java User Group")
+						.type(CommunityType.CLOSED)
+						.description("Community for Java developers")
+						.build())
+				.creationDatetime(LocalDateTime.of(2019, 1, 15, 20, 0))
+				.id("123")
+				.build())));
+	}
+
+	@DisplayName("Throws exception when null is passed as collection to delete community user registrations.")
+	@Test
+	void throwsExceptionWhenNullIsPassedAsCollectionToDeleteCommunityUserRegistrations() {
+		assertThrows(IllegalArgumentException.class, () -> communityUserRegistrationCommandService.delete(null));
 	}
 
 }

--- a/src/test/java/com/tsmms/skoop/communityuser/registration/query/CommunityUserRegistrationQueryServiceTests.java
+++ b/src/test/java/com/tsmms/skoop/communityuser/registration/query/CommunityUserRegistrationQueryServiceTests.java
@@ -14,9 +14,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith(MockitoExtension.class)
 class CommunityUserRegistrationQueryServiceTests {
@@ -108,6 +110,103 @@ class CommunityUserRegistrationQueryServiceTests {
 				.build());
 		assertThat(registration.getApprovedByCommunity()).isFalse();
 		assertThat(registration.getApprovedByUser()).isTrue();
+	}
+
+	@DisplayName("Gets pending invitations to join community.")
+	@Test
+	void getsPendingInvitationsToJoinCommunity() {
+		given(communityUserRegistrationRepository.findByCommunityIdAndApprovedByUserIsNullAndApprovedByCommunityIsTrue("123")).willReturn(
+			Stream.of(
+					CommunityUserRegistration.builder()
+							.approvedByCommunity(true)
+							.approvedByUser(null)
+							.community(Community.builder()
+									.title("Java User Group")
+									.id("123")
+									.type(CommunityType.OPEN)
+									.build())
+							.registeredUser(User.builder()
+									.id("456")
+									.userName("tester")
+									.build())
+							.id("abc")
+							.creationDatetime(LocalDateTime.of(2019, 1, 20, 10, 0))
+							.build()
+			)
+		);
+		final Stream<CommunityUserRegistration> communityUserRegistrationStream = communityUserRegistrationQueryService.getPendingInvitationsToJoinCommunity("123");
+		assertThat(communityUserRegistrationStream).containsExactlyInAnyOrder(
+				CommunityUserRegistration.builder()
+						.approvedByCommunity(true)
+						.approvedByUser(null)
+						.community(Community.builder()
+								.title("Java User Group")
+								.id("123")
+								.type(CommunityType.OPEN)
+								.build())
+						.registeredUser(User.builder()
+								.id("456")
+								.userName("tester")
+								.build())
+						.id("abc")
+						.creationDatetime(LocalDateTime.of(2019, 1, 20, 10, 0))
+						.build()
+		);
+	}
+
+	@DisplayName("Throws exception if null is passed as community id when getting pending invitations to join community.")
+	@Test
+	void throwsExceptionIfNullIsPassedAsCommunityIdWhenGettingPendingInvitationsToJoinCommunity() {
+		assertThrows(IllegalArgumentException.class, () -> communityUserRegistrationQueryService.getPendingInvitationsToJoinCommunity(null));
+	}
+
+	@DisplayName("Gets pending user requests to join community.")
+	@Test
+	void getsPendingUserRequestsToJoinCommunity() {
+		given(communityUserRegistrationRepository.findByCommunityIdAndApprovedByUserIsTrueAndApprovedByCommunityIsNull("123")).willReturn(
+				Stream.of(
+						CommunityUserRegistration.builder()
+								.approvedByCommunity(null)
+								.approvedByUser(true)
+								.community(Community.builder()
+										.title("Java User Group")
+										.id("123")
+										.type(CommunityType.OPEN)
+										.build())
+								.registeredUser(User.builder()
+										.id("456")
+										.userName("tester")
+										.build())
+								.id("abc")
+								.creationDatetime(LocalDateTime.of(2019, 1, 20, 10, 0))
+								.build()
+				)
+		);
+		final Stream<CommunityUserRegistration> communityUserRegistrationStream = communityUserRegistrationQueryService.getPendingUserRequestsToJoinCommunity("123");
+		assertThat(communityUserRegistrationStream).containsExactlyInAnyOrder(
+				CommunityUserRegistration.builder()
+						.approvedByCommunity(null)
+						.approvedByUser(true)
+						.community(Community.builder()
+								.title("Java User Group")
+								.id("123")
+								.type(CommunityType.OPEN)
+								.build())
+						.registeredUser(User.builder()
+								.id("456")
+								.userName("tester")
+								.build())
+						.id("abc")
+						.creationDatetime(LocalDateTime.of(2019, 1, 20, 10, 0))
+						.build()
+		);
+	}
+
+
+	@DisplayName("Throws exception if null is passed as community id when getting pending user requests to join community.")
+	@Test
+	void throwsExceptionIfNullIsPassedAsCommunityIdWhenGettingPendingUserRequestsToJoinCommunity() {
+		assertThrows(IllegalArgumentException.class, () -> communityUserRegistrationQueryService.getPendingUserRequestsToJoinCommunity(null));
 	}
 
 }


### PR DESCRIPTION
The user sent a request to join a community is notified when the community is deleted.
The invitations to users to join a community is deleted when the community is deleted.
Tests.