### PR TITLE
feature/SKOOP-124

### DIFF
--- a/src/main/java/com/tsmms/skoop/notification/NotificationRepository.java
+++ b/src/main/java/com/tsmms/skoop/notification/NotificationRepository.java
@@ -41,4 +41,7 @@ public interface NotificationRepository extends Neo4jRepository<Notification, St
 			" ORDER BY n.creationDatetime DESC")
 	Stream<Notification> getUserNotifications(@Param("userId") String userId);
 
+	@Query("MATCH (n:Notification)-[:CAUSED_BY]->(registration:CommunityUserRegistration {id: {registrationId}}) RETURN n")
+	Stream<Notification> findByRegistrationId(@Param("registrationId") String registrationId);
+
 }

--- a/src/main/java/com/tsmms/skoop/notification/command/NotificationCommandService.java
+++ b/src/main/java/com/tsmms/skoop/notification/command/NotificationCommandService.java
@@ -5,6 +5,8 @@ import com.tsmms.skoop.notification.NotificationRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collection;
+
 import static java.util.Objects.requireNonNull;
 
 @Service
@@ -19,6 +21,16 @@ public class NotificationCommandService {
 	@Transactional
 	public Notification save(Notification notification) {
 		return notificationRepository.save(notification);
+	}
+
+	@Transactional
+	public void delete(Notification notification) {
+		notificationRepository.delete(notification);
+	}
+
+	@Transactional
+	public void delete(Collection<Notification> notifications) {
+		notificationRepository.deleteAll(notifications);
 	}
 
 }

--- a/src/main/java/com/tsmms/skoop/notification/query/NotificationQueryService.java
+++ b/src/main/java/com/tsmms/skoop/notification/query/NotificationQueryService.java
@@ -23,4 +23,9 @@ public class NotificationQueryService {
 		return notificationRepository.getUserNotifications(userId);
 	}
 
+	@Transactional(readOnly = true)
+	public Stream<Notification> getNotificationsByCommunityUserRegistrationId(String registrationId) {
+		return notificationRepository.findByRegistrationId(registrationId);
+	}
+
 }

--- a/src/test/java/com/tsmms/skoop/communityuser/registration/command/CommunityUserRegistrationCommandServiceTests.java
+++ b/src/test/java/com/tsmms/skoop/communityuser/registration/command/CommunityUserRegistrationCommandServiceTests.java
@@ -2,6 +2,7 @@ package com.tsmms.skoop.communityuser.registration.command;
 
 import com.tsmms.skoop.community.Community;
 import com.tsmms.skoop.community.CommunityType;
+import com.tsmms.skoop.notification.query.NotificationQueryService;
 import com.tsmms.skoop.user.User;
 import com.tsmms.skoop.communityuser.command.CommunityUserCommandService;
 import com.tsmms.skoop.communityuser.registration.CommunityUserRegistration;
@@ -44,12 +45,15 @@ class CommunityUserRegistrationCommandServiceTests {
 	@Mock
 	private NotificationCommandService notificationCommandService;
 
+	@Mock
+	private NotificationQueryService notificationQueryService;
+
 	private CommunityUserRegistrationCommandService communityUserRegistrationCommandService;
 
 	@BeforeEach
 	void setUp() {
 		this.communityUserRegistrationCommandService = new CommunityUserRegistrationCommandService(communityUserRegistrationRepository,
-				communityUserCommandService, notificationCommandService);
+				communityUserCommandService, notificationCommandService, notificationQueryService);
 	}
 
 	@DisplayName("Test if users are invited.")
@@ -420,6 +424,90 @@ class CommunityUserRegistrationCommandServiceTests {
 		assertThat(registration.getId()).isEqualTo("123");
 		assertThat(registration.getApprovedByUser()).isTrue();
 		assertThat(registration.getApprovedByCommunity()).isTrue();
+		assertThat(registration.getCreationDatetime()).isEqualTo(LocalDateTime.of(2019, 1, 15, 20, 0));
+		assertThat(registration.getCommunity()).isEqualTo(Community.builder()
+				.id("123")
+				.title("Java User Group")
+				.type(CommunityType.CLOSED)
+				.description("Community for Java developers")
+				.build());
+		assertThat(registration.getRegisteredUser()).isEqualTo(
+				User.builder()
+						.id("db87d46a-e4ca-451a-903b-e8533e0b924b")
+						.userName("tester")
+						.build()
+		);
+	}
+
+	@DisplayName("Decline community user registration on behalf of user.")
+	@Test
+	void declineOnBehalfOfUser() {
+		final CommunityUserRegistration registration = communityUserRegistrationCommandService.approve(CommunityUserRegistration.builder()
+						.approvedByCommunity(true)
+						.approvedByUser(null)
+						.registeredUser(User.builder()
+								.id("db87d46a-e4ca-451a-903b-e8533e0b924b")
+								.userName("tester")
+								.build())
+						.community(Community.builder()
+								.id("123")
+								.title("Java User Group")
+								.type(CommunityType.CLOSED)
+								.description("Community for Java developers")
+								.build())
+						.creationDatetime(LocalDateTime.of(2019, 1, 15, 20, 0))
+						.id("123")
+						.build(),
+				CommunityUserRegistrationApprovalCommand.builder()
+						.approvedByUser(false)
+						.approvedByCommunity(null)
+						.build()
+		);
+		assertThat(registration.getId()).isEqualTo("123");
+		assertThat(registration.getApprovedByUser()).isFalse();
+		assertThat(registration.getApprovedByCommunity()).isTrue();
+		assertThat(registration.getCreationDatetime()).isEqualTo(LocalDateTime.of(2019, 1, 15, 20, 0));
+		assertThat(registration.getCommunity()).isEqualTo(Community.builder()
+				.id("123")
+				.title("Java User Group")
+				.type(CommunityType.CLOSED)
+				.description("Community for Java developers")
+				.build());
+		assertThat(registration.getRegisteredUser()).isEqualTo(
+				User.builder()
+						.id("db87d46a-e4ca-451a-903b-e8533e0b924b")
+						.userName("tester")
+						.build()
+		);
+	}
+
+	@DisplayName("Decline community user registration on behalf of community.")
+	@Test
+	void declineOnBehalfOfCommunity() {
+		final CommunityUserRegistration registration = communityUserRegistrationCommandService.approve(CommunityUserRegistration.builder()
+						.approvedByCommunity(null)
+						.approvedByUser(true)
+						.registeredUser(User.builder()
+								.id("db87d46a-e4ca-451a-903b-e8533e0b924b")
+								.userName("tester")
+								.build())
+						.community(Community.builder()
+								.id("123")
+								.title("Java User Group")
+								.type(CommunityType.CLOSED)
+								.description("Community for Java developers")
+								.build())
+						.creationDatetime(LocalDateTime.of(2019, 1, 15, 20, 0))
+						.id("123")
+						.build(),
+				CommunityUserRegistrationApprovalCommand.builder()
+						.approvedByUser(null)
+						.approvedByCommunity(false)
+						.build()
+		);
+		assertThat(registration.getId()).isEqualTo("123");
+		assertThat(registration.getApprovedByUser()).isTrue();
+		assertThat(registration.getApprovedByCommunity()).isFalse();
 		assertThat(registration.getCreationDatetime()).isEqualTo(LocalDateTime.of(2019, 1, 15, 20, 0));
 		assertThat(registration.getCommunity()).isEqualTo(Community.builder()
 				.id("123")

--- a/src/test/java/com/tsmms/skoop/notification/NotificationRepositoryTests.java
+++ b/src/test/java/com/tsmms/skoop/notification/NotificationRepositoryTests.java
@@ -28,6 +28,7 @@ import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static java.util.stream.Collectors.toList;
@@ -507,6 +508,56 @@ class NotificationRepositoryTests {
 		assertThat(requestToJoinCommunityNotification.getRegistration().getId()).isEqualTo("123456");
 		assertThat(requestToJoinCommunityNotification.getRegistration().getCreationDatetime()).isEqualTo(LocalDateTime.of(2019, 3, 26, 11, 0));
 		assertThat(requestToJoinCommunityNotification.getCommunityName()).isEqualTo("JavaScript User Group");
+	}
+
+	@DisplayName("Finds notifications by community user registration ID.")
+	@Test
+	void findsNotificationsByCommunityUserRegistrationId() {
+		notificationRepository.save(
+				InvitationToJoinCommunityNotification.builder()
+						.id("123")
+						.creationDatetime(LocalDateTime.of(2019, 3, 27, 9, 34))
+						.registration(CommunityUserRegistration.builder()
+								.id("abc")
+								.approvedByUser(null)
+								.approvedByCommunity(true)
+								.registeredUser(User.builder()
+										.id("abc")
+										.userName("tester")
+										.build())
+								.community(Community.builder()
+										.id("cba")
+										.type(CommunityType.CLOSED)
+										.title("Community")
+										.build()
+								)
+								.build())
+						.communityName("Community")
+						.build()
+		);
+		final Stream<Notification> notificationStream = notificationRepository.findByRegistrationId("abc");
+		assertThat(notificationStream).containsExactlyInAnyOrder(
+				InvitationToJoinCommunityNotification.builder()
+						.id("123")
+						.creationDatetime(LocalDateTime.of(2019, 3, 27, 9, 34))
+						.registration(CommunityUserRegistration.builder()
+								.id("abc")
+								.approvedByUser(null)
+								.approvedByCommunity(true)
+								.registeredUser(User.builder()
+										.id("abc")
+										.userName("tester")
+										.build())
+								.community(Community.builder()
+										.id("cba")
+										.type(CommunityType.CLOSED)
+										.title("Community")
+										.build()
+								)
+								.build())
+						.communityName("Community")
+						.build()
+		);
 	}
 
 }

--- a/src/test/java/com/tsmms/skoop/notification/query/NotificationQueryServiceTests.java
+++ b/src/test/java/com/tsmms/skoop/notification/query/NotificationQueryServiceTests.java
@@ -257,4 +257,56 @@ class NotificationQueryServiceTests {
 		);
 	}
 
+	@DisplayName("Gets notifications by community user registration ID.")
+	@Test
+	void getsNotificationByCommunityUserRegistrationId() {
+		given(notificationRepository.findByRegistrationId("abc")).willReturn(
+				Stream.of(
+						InvitationToJoinCommunityNotification.builder()
+								.id("123")
+								.creationDatetime(LocalDateTime.of(2019, 3, 27, 9, 34))
+								.registration(CommunityUserRegistration.builder()
+										.id("abc")
+										.approvedByUser(null)
+										.approvedByCommunity(true)
+										.registeredUser(User.builder()
+												.id("abc")
+												.userName("tester")
+												.build())
+										.community(Community.builder()
+												.id("cba")
+												.type(CommunityType.CLOSED)
+												.title("Community")
+												.build()
+										)
+										.build())
+								.communityName("Community")
+								.build()
+				)
+		);
+		final Stream<Notification> notificationStream = notificationQueryService.getNotificationsByCommunityUserRegistrationId("abc");
+		assertThat(notificationStream).containsExactlyInAnyOrder(
+				InvitationToJoinCommunityNotification.builder()
+						.id("123")
+						.creationDatetime(LocalDateTime.of(2019, 3, 27, 9, 34))
+						.registration(CommunityUserRegistration.builder()
+								.id("abc")
+								.approvedByUser(null)
+								.approvedByCommunity(true)
+								.registeredUser(User.builder()
+										.id("abc")
+										.userName("tester")
+										.build())
+								.community(Community.builder()
+										.id("cba")
+										.type(CommunityType.CLOSED)
+										.title("Community")
+										.build()
+								)
+								.build())
+						.communityName("Community")
+						.build()
+		);
+	}
+
 }


### PR DESCRIPTION
The to-dos that were dealt with are deleted from the database.
The declined community user registrations are removed immediately.
The accepted community user registrations are still in the database (it is planned to remove them as soon as AcceptanceToCommunityNotification is deleted).
Tests.
@svetivanova could you please take a look?