### PR TITLE
Optimize performance by caching of user ID mapping

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,14 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-cache</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.github.ben-manes.caffeine</groupId>
+			<artifactId>caffeine</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-neo4j</artifactId>
 		</dependency>
 		<dependency>

--- a/src/main/java/com/tsmms/skoop/SkoopServerApplication.java
+++ b/src/main/java/com/tsmms/skoop/SkoopServerApplication.java
@@ -3,6 +3,7 @@ package com.tsmms.skoop;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.web.servlet.ServletComponentScan;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.neo4j.repository.config.EnableNeo4jRepositories;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 @EnableNeo4jRepositories
 @EnableTransactionManagement
 @Transactional(rollbackFor = Exception.class)
+@EnableCaching
 public class SkoopServerApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(SkoopServerApplication.class, args);

--- a/src/main/java/com/tsmms/skoop/user/UserRepository.java
+++ b/src/main/java/com/tsmms/skoop/user/UserRepository.java
@@ -11,6 +11,9 @@ import java.util.Optional;
 public interface UserRepository extends Neo4jRepository<User, String> {
 	Optional<User> findByUserName(String userName);
 
+	@Query("MATCH (user:User {userName:{userName}}) RETURN user.id")
+	Optional<String> findUserIdByUserName(@Param("userName") String userName);
+
 	Optional<User> findByReferenceId(String referenceId);
 
 	@Query("MATCH (user:User) " +

--- a/src/main/java/com/tsmms/skoop/user/query/UserQueryService.java
+++ b/src/main/java/com/tsmms/skoop/user/query/UserQueryService.java
@@ -47,7 +47,7 @@ public class UserQueryService {
 	}
 
 	@Transactional(readOnly = true)
-	@Cacheable(cacheNames = "userIds", unless = "#result.empty")
+	@Cacheable(cacheNames = "userIds", unless = "#result == null")
 	public Optional<String> getUserIdByUserName(String userName) {
 		return userRepository.findUserIdByUserName(userName);
 	}

--- a/src/main/java/com/tsmms/skoop/user/query/UserQueryService.java
+++ b/src/main/java/com/tsmms/skoop/user/query/UserQueryService.java
@@ -3,6 +3,7 @@ package com.tsmms.skoop.user.query;
 import com.tsmms.skoop.exception.EmptyInputException;
 import com.tsmms.skoop.user.User;
 import com.tsmms.skoop.user.UserRepository;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,6 +44,12 @@ public class UserQueryService {
 	@Transactional(readOnly = true)
 	public Optional<User> getByUserName(String userName) {
 		return userRepository.findByUserName(userName);
+	}
+
+	@Transactional(readOnly = true)
+	@Cacheable(cacheNames = "userIds", unless = "#result.empty")
+	public Optional<String> getUserIdByUserName(String userName) {
+		return userRepository.findUserIdByUserName(userName);
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/tsmms/skoop/user/query/UserQueryService.java
+++ b/src/main/java/com/tsmms/skoop/user/query/UserQueryService.java
@@ -46,7 +46,6 @@ public class UserQueryService {
 		return userRepository.findByUserName(userName);
 	}
 
-	@Transactional(readOnly = true)
 	@Cacheable(cacheNames = "userIds", unless = "#result == null")
 	public Optional<String> getUserIdByUserName(String userName) {
 		return userRepository.findUserIdByUserName(userName);

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -24,3 +24,7 @@ spring:
       pool:
         max-size: 50
         queue-capacity: 100
+  cache:
+    cache-names: userIds
+    caffeine:
+      spec: maximumSize=2000,expireAfterAccess=3600s

--- a/src/test/java/com/tsmms/skoop/security/UserClaimSetConverterTests.java
+++ b/src/test/java/com/tsmms/skoop/security/UserClaimSetConverterTests.java
@@ -34,12 +34,7 @@ class UserClaimSetConverterTests {
 	@Test
 	@DisplayName("User claim set is enriched with a user id when the user exists.")
 	void testIfUserClaimSetIsEnrichedWithUserIdWhenUserExists() {
-		given(userQueryService.getByUserName("johndoe")).willReturn(Optional.of(
-				User.builder()
-						.id("123")
-						.userName("johndoe")
-						.build()
-		));
+		given(userQueryService.getUserIdByUserName("johndoe")).willReturn(Optional.of("123"));
 		final Map<String, Object> claims = new HashMap<>();
 		claims.put("given_name", "John");
 		claims.put("family_name", "Doe");
@@ -48,14 +43,13 @@ class UserClaimSetConverterTests {
 		claims.put("jti", "38929539-bbac-4d4a-be9b-9ba2305f0f51");
 		claims.put("session_state", "355b7a43-ef3a-4e85-9e95-cde240e47d56");
 		final Map<String, Object> enrichedClaims = userClaimSetConverter.convert(claims);
-		assertThat(enrichedClaims).containsKeys("skoop_user_id");
-		assertThat(enrichedClaims).containsValues("123");
+		assertThat(enrichedClaims).containsEntry(JwtClaims.SKOOP_USER_ID, "123");
 	}
 
 	@Test
 	@DisplayName("User claim set is enriched with a user id when the user does not exist.")
 	void testIfUserClaimSetIsEnrichedWithUserIdWhenUserDoesNotExist() {
-		given(userQueryService.getByUserName("johndoe")).willReturn(Optional.empty());
+		given(userQueryService.getUserIdByUserName("johndoe")).willReturn(Optional.empty());
 		given(userCommandService.createUser("johndoe", "John", "Doe", "johndoe@mail.com")).willReturn(
 				User.builder()
 						.id("123")
@@ -72,8 +66,7 @@ class UserClaimSetConverterTests {
 		claims.put("jti", "38929539-bbac-4d4a-be9b-9ba2305f0f51");
 		claims.put("session_state", "355b7a43-ef3a-4e85-9e95-cde240e47d56");
 		final Map<String, Object> enrichedClaims = userClaimSetConverter.convert(claims);
-		assertThat(enrichedClaims).containsKeys("skoop_user_id");
-		assertThat(enrichedClaims).containsValues("123");
+		assertThat(enrichedClaims).containsEntry(JwtClaims.SKOOP_USER_ID, "123");
 	}
 
 }

--- a/src/test/java/com/tsmms/skoop/user/query/UserQueryServiceCachingTests.java
+++ b/src/test/java/com/tsmms/skoop/user/query/UserQueryServiceCachingTests.java
@@ -1,0 +1,53 @@
+package com.tsmms.skoop.user.query;
+
+import com.tsmms.skoop.user.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import java.util.Optional;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, properties = {"liquigraph.enabled=false"})
+@ActiveProfiles("test")
+class UserQueryServiceCachingTests {
+	@MockBean
+	private UserRepository userRepository;
+	@MockBean
+	private ConversionService conversionService;
+	@MockBean
+	private PlatformTransactionManager transactionManager;
+
+	@Autowired
+	private UserQueryService userQueryService;
+
+	@Test
+	@DisplayName("Retrieves the user ID from the repository only once if user exists")
+	void retrievesUserIdFromRepositoryOnlyOnceForExistingUser() {
+		given(userRepository.findUserIdByUserName("johndoe")).willReturn(Optional.of("123"));
+		userQueryService.getUserIdByUserName("johndoe");
+		userQueryService.getUserIdByUserName("johndoe");
+		userQueryService.getUserIdByUserName("johndoe");
+		then(userRepository).should(times(1)).findUserIdByUserName("johndoe");
+		then(userRepository).shouldHaveNoMoreInteractions();
+	}
+
+	@Test
+	@DisplayName("Retrieves the user ID from the repository again if user does not exist")
+	void retrievesUserIdFromRepositoryAgainForNonExistingUser() {
+		given(userRepository.findUserIdByUserName("johndoe")).willReturn(Optional.empty());
+		userQueryService.getUserIdByUserName("johndoe");
+		userQueryService.getUserIdByUserName("johndoe");
+		userQueryService.getUserIdByUserName("johndoe");
+		then(userRepository).should(times(3)).findUserIdByUserName("johndoe");
+		then(userRepository).shouldHaveNoMoreInteractions();
+	}
+}

--- a/src/test/java/com/tsmms/skoop/user/query/UserQueryServiceCachingTests.java
+++ b/src/test/java/com/tsmms/skoop/user/query/UserQueryServiceCachingTests.java
@@ -8,7 +8,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.PlatformTransactionManager;
 
 import java.util.Optional;
 
@@ -23,8 +22,6 @@ class UserQueryServiceCachingTests {
 	private UserRepository userRepository;
 	@MockBean
 	private ConversionService conversionService;
-	@MockBean
-	private PlatformTransactionManager transactionManager;
 
 	@Autowired
 	private UserQueryService userQueryService;


### PR DESCRIPTION
The goal was to optimize performance of request processing by reducing the database overhead in the `UserClaimSetConverter`. This converter is executed in each request to enrich the JWT with the internal ID of the `User` who authenticates with the bearer token. Therefore, it is important that this procedure is fast.

The following measures were implemented:

- The `UserClaimSetConverter` retrieves only the user ID now, not the whole `User` entity. This way, we can use a much more optimized Cypher query which loads less data from the graph.
- The `UserQueryService` provides a new method to retrieve only the user ID for a given user name. This method additionally leverages Spring's caching support to reduce database access.

Thoughts on caching:

- We can cache the mapping from user name to user ID without any complicated eviction strategy because once a user has been created in the graph her/his ID cannot be changed.
- If a given user name is not found in the graph we MUST NOT cache the resulting `null` value for the user ID because then we would not find the user ID once the entity has been created. I put the `unless` parameter on the `Cacheable` annotation to take care of only caching non-null user IDs.

_UPDATE:_ I removed the transaction around the service method which returns the user ID for a given user name. In combination with the cache this reduced the runtime of the `UserClaimSetConverter` from about 15 ms to less than 0,5 ms in most cases.

@LebedkoDmitry @svetivanova Could you please have a look at this optimization?