### PR TITLE
bugfix/SKOOP-151

### DIFF
--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -19,6 +19,9 @@ neo4j:
 spring:
   datasource:
     driver-class-name: org.neo4j.jdbc.bolt.BoltDriver
+    hikari:
+      idle-timeout: 60000 # in milliseconds
+      minimum-idle: 0
   task:
     execution:
       pool:


### PR DESCRIPTION
Hikari connection pool has been set to consider connections not active for 60 seconds as idle ones.

The minimal number of idle connections has been set to zero to let connection pool be an empty one.
That has been done due to Liquigraph not closing connections when changelogs applied.