### PR TITLE
feature/SKOOP-182

### DIFF
--- a/src/main/java/com/tsmms/skoop/notification/NotificationRepository.java
+++ b/src/main/java/com/tsmms/skoop/notification/NotificationRepository.java
@@ -27,6 +27,8 @@ public interface NotificationRepository extends Neo4jRepository<Notification, St
 			" WITH notifications + collect(n) AS notifications " +
 			" OPTIONAL MATCH (n:UserSkillsEstimationNotification)-[:RECIPIENT]->(:User {id: {userId}}) " +
 			" WITH notifications + collect(n) AS notifications " +
+			" OPTIONAL MATCH (n:UserProjectNeedsApprovalNotification)-[:USER_PROJECT]->(:UserProject)-[:USER]->(:User)-[:MANAGER]->(:User {id: {userId}}) " +
+			" WITH notifications + collect(n) AS notifications " +
 			" OPTIONAL MATCH (n:UserWelcomeNotification)-[:RECIPIENT]->(:User {id: {userId}}) " +
 			" WITH notifications + collect(n) AS notifications " +
 			" OPTIONAL MATCH (n:RequestToJoinCommunityNotification)-[:CAUSED_BY]->(registration:CommunityUserRegistration)-[:community]->(c:Community)<-[:COMMUNITY_USER {role:'MANAGER'}]-(:User {id: {userId}}) " +
@@ -43,7 +45,9 @@ public interface NotificationRepository extends Neo4jRepository<Notification, St
 			" OPTIONAL MATCH (n)-[r5:USER]->(user:User) " +
 			" WITH n, r1, registration, r2, registeredUser, r3, c, r4, community, r5, user " +
 			" OPTIONAL MATCH (n)-[r6:SKILL]->(skill:Skill) " +
-			" RETURN n, r1, registration, r2, registeredUser, r3, c, r4, community, r5, user, r6, skill " +
+			" WITH n, r1, registration, r2, registeredUser, r3, c, r4, community, r5, user, r6, skill " +
+			" OPTIONAL MATCH (n)-[r7:USER_PROJECT]->(up:UserProject)-[r8:USER]->(u:User) " +
+			" RETURN n, r1, registration, r2, registeredUser, r3, c, r4, community, r5, user, r6, skill, r7, up, r8, u" +
 			" ORDER BY n.creationDatetime DESC")
 	Stream<Notification> getUserNotifications(@Param("userId") String userId);
 
@@ -63,6 +67,8 @@ public interface NotificationRepository extends Neo4jRepository<Notification, St
 			" OPTIONAL MATCH (n:CommunityChangedNotification)-[:RECIPIENT]->(:User {id: {userId}}) " +
 			" WITH notifications + collect(n) AS notifications " +
 			" OPTIONAL MATCH (n:UserSkillsEstimationNotification)-[:RECIPIENT]->(:User {id: {userId}}) " +
+			" WITH notifications + collect(n) AS notifications " +
+			" OPTIONAL MATCH (n:UserProjectNeedsApprovalNotification)-[:USER_PROJECT]->(:UserProject)-[:USER]->(:User)-[:MANAGER]->(:User {id: {userId}}) " +
 			" WITH notifications + collect(n) AS notifications " +
 			" OPTIONAL MATCH (n:UserWelcomeNotification)-[:RECIPIENT]->(:User {id: {userId}}) " +
 			" WITH notifications + collect(n) AS notifications " +

--- a/src/main/java/com/tsmms/skoop/project/ProjectResponse.java
+++ b/src/main/java/com/tsmms/skoop/project/ProjectResponse.java
@@ -35,6 +35,9 @@ public class ProjectResponse {
 	private LocalDateTime lastModifiedDate;
 
 	public static ProjectResponse of(Project project) {
+		if (project == null) {
+			return null;
+		}
 		return ProjectResponse.builder()
 				.id(project.getId())
 				.name(project.getName())

--- a/src/main/java/com/tsmms/skoop/user/notification/UserNotificationQueryController.java
+++ b/src/main/java/com/tsmms/skoop/user/notification/UserNotificationQueryController.java
@@ -47,7 +47,8 @@ public class UserNotificationQueryController {
 	@GetMapping(path = "/users/{userId}/notifications", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<List<AbstractNotificationResponse>> getUserNotifications(@PathVariable("userId") String userId) {
 		return ResponseEntity.ok(notificationQueryService.getUserNotifications(userId)
-				.map(n -> conversionService.convert(n, AbstractNotificationResponse.class)).collect(Collectors.toList()));
+				.map(n -> conversionService.convert(n, AbstractNotificationResponse.class))
+				.collect(Collectors.toList()));
 	}
 
 	@ApiOperation(value = "Gets user notification counter.",

--- a/src/main/java/com/tsmms/skoop/userproject/UserProjectNeedsApprovalNotification.java
+++ b/src/main/java/com/tsmms/skoop/userproject/UserProjectNeedsApprovalNotification.java
@@ -1,0 +1,25 @@
+package com.tsmms.skoop.userproject;
+
+import com.tsmms.skoop.notification.Notification;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.neo4j.ogm.annotation.Relationship;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserProjectNeedsApprovalNotification extends Notification {
+
+	@Relationship(type = "USER_PROJECT")
+	private UserProject userProject;
+
+	@Builder
+	public UserProjectNeedsApprovalNotification(String id, LocalDateTime creationDatetime, UserProject userProject) {
+		super(id, creationDatetime);
+		this.userProject = userProject;
+	}
+}

--- a/src/main/java/com/tsmms/skoop/userproject/UserProjectNeedsApprovalNotificationConverter.java
+++ b/src/main/java/com/tsmms/skoop/userproject/UserProjectNeedsApprovalNotificationConverter.java
@@ -1,0 +1,14 @@
+package com.tsmms.skoop.userproject;
+
+import com.tsmms.skoop.notification.AbstractNotificationResponse;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserProjectNeedsApprovalNotificationConverter implements Converter<UserProjectNeedsApprovalNotification, AbstractNotificationResponse> {
+
+	@Override
+	public AbstractNotificationResponse convert(UserProjectNeedsApprovalNotification notification) {
+		return UserProjectNeedsApprovalNotificationResponse.of(notification);
+	}
+}

--- a/src/main/java/com/tsmms/skoop/userproject/UserProjectNeedsApprovalNotificationResponse.java
+++ b/src/main/java/com/tsmms/skoop/userproject/UserProjectNeedsApprovalNotificationResponse.java
@@ -1,0 +1,44 @@
+package com.tsmms.skoop.userproject;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.tsmms.skoop.notification.AbstractNotificationResponse;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@ApiModel(
+		value = "UserProjectNeedsApprovalNotificationResponse",
+		description = "This holds notification data about necessity for" +
+				" a manager to approve project membership of her / his subordinate. " +
+				"It is used to transfer notification data about necessity for a manager" +
+				" to approve project membership of her / his subordinate to a client."
+)
+@JsonTypeName("UserProjectNeedsApprovalNotification")
+public class UserProjectNeedsApprovalNotificationResponse extends AbstractNotificationResponse {
+
+	@ApiModelProperty("The project membership.")
+	private UserProjectResponse userProject;
+
+	@Builder
+	public UserProjectNeedsApprovalNotificationResponse(String id, LocalDateTime creationDatetime, UserProjectResponse userProject) {
+		super(id, creationDatetime);
+		this.userProject = userProject;
+	}
+
+	public static UserProjectNeedsApprovalNotificationResponse of(UserProjectNeedsApprovalNotification notification) {
+		return UserProjectNeedsApprovalNotificationResponse.builder()
+				.id(notification.getId())
+				.creationDatetime(notification.getCreationDatetime())
+				.userProject(UserProjectResponse.of(notification.getUserProject()))
+				.build();
+	}
+
+}

--- a/src/main/java/com/tsmms/skoop/userproject/command/UserProjectCommandService.java
+++ b/src/main/java/com/tsmms/skoop/userproject/command/UserProjectCommandService.java
@@ -104,7 +104,14 @@ public class UserProjectCommandService {
 		userProject.setCreationDate(now);
 		userProject.setLastModifiedDate(now);
 		userProject.setApproved(false);
-		return userProjectRepository.save(userProject);
+		final UserProject newUserProject = userProjectRepository.save(userProject);
+		notificationCommandService.save(UserProjectNeedsApprovalNotification.builder()
+				.id(UUID.randomUUID().toString())
+				.userProject(newUserProject)
+				.creationDatetime(LocalDateTime.now())
+				.build()
+		);
+		return newUserProject;
 	}
 
 	@Transactional

--- a/src/main/java/com/tsmms/skoop/userproject/command/UserProjectCommandService.java
+++ b/src/main/java/com/tsmms/skoop/userproject/command/UserProjectCommandService.java
@@ -12,6 +12,7 @@ import com.tsmms.skoop.user.User;
 import com.tsmms.skoop.user.query.UserQueryService;
 import com.tsmms.skoop.exception.enums.Model;
 import com.tsmms.skoop.userproject.UserProject;
+import com.tsmms.skoop.userproject.UserProjectNeedsApprovalNotification;
 import com.tsmms.skoop.userproject.UserProjectRepository;
 import com.tsmms.skoop.userskill.UserSkillsEstimationNotification;
 import com.tsmms.skoop.userskill.command.UserSkillCommandService;
@@ -133,7 +134,14 @@ public class UserProjectCommandService {
 		final LocalDateTime now = LocalDateTime.now();
 		userProject.setLastModifiedDate(now);
 		userProject.setApproved(false);
-		return userProjectRepository.save(userProject);
+		final UserProject newUserProject = userProjectRepository.save(userProject);
+		notificationCommandService.save(UserProjectNeedsApprovalNotification.builder()
+				.id(UUID.randomUUID().toString())
+				.userProject(newUserProject)
+				.creationDatetime(LocalDateTime.now())
+				.build()
+		);
+		return newUserProject;
 	}
 
 	@Transactional

--- a/src/test/java/com/tsmms/skoop/notification/NotificationRepositoryTests.java
+++ b/src/test/java/com/tsmms/skoop/notification/NotificationRepositoryTests.java
@@ -20,6 +20,8 @@ import com.tsmms.skoop.skill.Skill;
 import com.tsmms.skoop.user.User;
 import com.tsmms.skoop.user.UserRepository;
 import com.tsmms.skoop.user.notification.UserWelcomeNotification;
+import com.tsmms.skoop.userproject.UserProject;
+import com.tsmms.skoop.userproject.UserProjectNeedsApprovalNotification;
 import com.tsmms.skoop.userskill.UserSkillsEstimationNotification;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -242,9 +244,41 @@ class NotificationRepositoryTests {
 				.build()
 		);
 
+		notificationRepository.saveAll(
+				Arrays.asList(
+						UserProjectNeedsApprovalNotification.builder()
+								.id("aaa")
+								.creationDatetime(LocalDateTime.of(2014, 5, 8, 16, 30))
+								.userProject(UserProject.builder()
+										.id("abc")
+										.user(User.builder()
+												.id("123456")
+												.userName("firstSubordinate")
+												.manager(communityManager)
+												.build()
+										)
+										.build()
+								)
+								.build(),
+						UserProjectNeedsApprovalNotification.builder()
+								.id("bbb")
+								.creationDatetime(LocalDateTime.of(2014, 5, 8, 16, 29))
+								.userProject(UserProject.builder()
+										.id("def")
+										.user(User.builder()
+												.id("654321")
+												.userName("secondSubordinate")
+												.manager(communityManager)
+												.build()
+										)
+										.build()
+								)
+								.build()
+				));
+
 		final List<Notification> notifications = notificationRepository.getUserNotifications("123").collect(toList());
 
-		Assertions.assertThat(notifications).hasSize(8);
+		assertThat(notifications).hasSize(10);
 		Notification notification = notifications.get(0);
 		assertThat(notification.getId()).isEqualTo("def");
 		assertThat(notification.getCreationDatetime()).isEqualTo(LocalDateTime.of(2019, 3, 26, 11, 0));
@@ -337,6 +371,38 @@ class NotificationRepositoryTests {
 				Skill.builder()
 						.id("456")
 						.name("Angular")
+						.build()
+		);
+
+		notification = notifications.get(8);
+		assertThat(notification.getId()).isEqualTo("aaa");
+		assertThat(notification.getCreationDatetime()).isEqualTo(LocalDateTime.of(2014, 5, 8, 16, 30));
+		assertThat(notification).isInstanceOf(UserProjectNeedsApprovalNotification.class);
+		UserProjectNeedsApprovalNotification userProjectNeedsApprovalNotification = (UserProjectNeedsApprovalNotification) notification;
+		assertThat(userProjectNeedsApprovalNotification.getUserProject()).isEqualTo(
+				UserProject.builder()
+						.id("abc")
+						.user(User.builder()
+								.id("123456")
+								.userName("firstSubordinate")
+								.build()
+						)
+						.build()
+		);
+
+		notification = notifications.get(9);
+		assertThat(notification.getId()).isEqualTo("bbb");
+		assertThat(notification.getCreationDatetime()).isEqualTo(LocalDateTime.of(2014, 5, 8, 16, 29));
+		assertThat(notification).isInstanceOf(UserProjectNeedsApprovalNotification.class);
+		userProjectNeedsApprovalNotification = (UserProjectNeedsApprovalNotification) notification;
+		assertThat(userProjectNeedsApprovalNotification.getUserProject()).isEqualTo(
+				UserProject.builder()
+						.id("def")
+						.user(User.builder()
+								.id("654321")
+								.userName("secondSubordinate")
+								.build()
+						)
 						.build()
 		);
 	}
@@ -444,9 +510,41 @@ class NotificationRepositoryTests {
 				.build()
 		);
 
+		notificationRepository.saveAll(Arrays.asList(
+				UserProjectNeedsApprovalNotification.builder()
+						.id("aaa")
+						.creationDatetime(LocalDateTime.of(2014, 5, 8, 16, 30))
+						.userProject(UserProject.builder()
+								.id("abc")
+								.user(User.builder()
+										.id("123456")
+										.userName("firstSubordinate")
+										.manager(commonUser)
+										.build()
+								)
+								.build()
+						)
+						.build(),
+				UserProjectNeedsApprovalNotification.builder()
+						.id("bbb")
+						.creationDatetime(LocalDateTime.of(2014, 5, 8, 16, 29))
+						.userProject(UserProject.builder()
+								.id("def")
+								.user(User.builder()
+										.id("654321")
+										.userName("secondSubordinate")
+										.manager(commonUser)
+										.build()
+								)
+								.build()
+						)
+						.build()
+				)
+		);
+
 		final List<Notification> notifications = notificationRepository.getUserNotifications("123").collect(toList());
 
-		Assertions.assertThat(notifications).hasSize(7);
+		assertThat(notifications).hasSize(9);
 
 		Notification notification = notifications.get(0);
 		assertThat(notification.getId()).isEqualTo("abc");
@@ -527,6 +625,38 @@ class NotificationRepositoryTests {
 				Skill.builder()
 						.id("456")
 						.name("Angular")
+						.build()
+		);
+
+		notification = notifications.get(7);
+		assertThat(notification.getId()).isEqualTo("aaa");
+		assertThat(notification.getCreationDatetime()).isEqualTo(LocalDateTime.of(2014, 5, 8, 16, 30));
+		assertThat(notification).isInstanceOf(UserProjectNeedsApprovalNotification.class);
+		UserProjectNeedsApprovalNotification userProjectNeedsApprovalNotification = (UserProjectNeedsApprovalNotification) notification;
+		assertThat(userProjectNeedsApprovalNotification.getUserProject()).isEqualTo(
+				UserProject.builder()
+						.id("abc")
+						.user(User.builder()
+								.id("123456")
+								.userName("firstSubordinate")
+								.build()
+						)
+						.build()
+		);
+
+		notification = notifications.get(8);
+		assertThat(notification.getId()).isEqualTo("bbb");
+		assertThat(notification.getCreationDatetime()).isEqualTo(LocalDateTime.of(2014, 5, 8, 16, 29));
+		assertThat(notification).isInstanceOf(UserProjectNeedsApprovalNotification.class);
+		userProjectNeedsApprovalNotification = (UserProjectNeedsApprovalNotification) notification;
+		assertThat(userProjectNeedsApprovalNotification.getUserProject()).isEqualTo(
+				UserProject.builder()
+						.id("def")
+						.user(User.builder()
+								.id("654321")
+								.userName("secondSubordinate")
+								.build()
+						)
 						.build()
 		);
 	}
@@ -840,7 +970,41 @@ class NotificationRepositoryTests {
 				.build()
 		);
 
-		assertThat(notificationRepository.getUserNotificationCounter("123")).isEqualTo(8);
+		notificationRepository.saveAll(Arrays.asList(
+				UserProjectNeedsApprovalNotification.builder()
+						.id("aaa")
+						.creationDatetime(LocalDateTime.of(2014, 5, 8, 16, 30))
+						.userProject(
+								UserProject.builder()
+										.id("abc")
+										.user(User.builder()
+												.id("123456")
+												.userName("firstSubordinate")
+												.manager(communityManager)
+												.build()
+										)
+										.build()
+						)
+						.build(),
+				UserProjectNeedsApprovalNotification.builder()
+						.id("bbb")
+						.creationDatetime(LocalDateTime.of(2014, 5, 8, 16, 29))
+						.userProject(
+								UserProject.builder()
+										.id("def")
+										.user(User.builder()
+												.id("654321")
+												.userName("secondSubordinate")
+												.manager(communityManager)
+												.build()
+										)
+										.build()
+						)
+						.build()
+				)
+		);
+
+		assertThat(notificationRepository.getUserNotificationCounter("123")).isEqualTo(10);
 	}
 
 }

--- a/src/test/java/com/tsmms/skoop/notification/query/NotificationQueryServiceTests.java
+++ b/src/test/java/com/tsmms/skoop/notification/query/NotificationQueryServiceTests.java
@@ -16,6 +16,8 @@ import com.tsmms.skoop.communityuser.registration.RequestToJoinCommunityNotifica
 import com.tsmms.skoop.notification.Notification;
 import com.tsmms.skoop.notification.NotificationRepository;
 import com.tsmms.skoop.user.User;
+import com.tsmms.skoop.userproject.UserProject;
+import com.tsmms.skoop.userproject.UserProjectNeedsApprovalNotification;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -149,6 +151,34 @@ class NotificationQueryServiceTests {
 								.title("Changed community")
 								.build())
 						.communityDetails(new HashSet<>(Arrays.asList(CommunityDetails.DESCRIPTION, CommunityDetails.TYPE)))
+						.build(),
+				UserProjectNeedsApprovalNotification.builder()
+						.id("aaa")
+						.creationDatetime(LocalDateTime.of(2014, 5, 8, 16, 30))
+						.userProject(
+								UserProject.builder()
+										.id("abc")
+										.user(User.builder()
+												.id("123456")
+												.userName("firstSubordinate")
+												.build()
+										)
+										.build()
+						)
+						.build(),
+				UserProjectNeedsApprovalNotification.builder()
+						.id("bbb")
+						.creationDatetime(LocalDateTime.of(2014, 5, 8, 16, 29))
+						.userProject(
+								UserProject.builder()
+										.id("def")
+										.user(User.builder()
+												.id("654321")
+												.userName("secondSubordinate")
+												.build()
+										)
+										.build()
+						)
 						.build()
 		));
 
@@ -254,6 +284,32 @@ class NotificationQueryServiceTests {
 								.title("Changed community")
 								.build())
 						.communityDetails(new HashSet<>(Arrays.asList(CommunityDetails.DESCRIPTION, CommunityDetails.TYPE)))
+						.build(),
+				UserProjectNeedsApprovalNotification.builder()
+						.id("aaa")
+						.creationDatetime(LocalDateTime.of(2014, 5, 8, 16, 30))
+						.userProject(UserProject.builder()
+										.id("abc")
+										.user(User.builder()
+												.id("123456")
+												.userName("firstSubordinate")
+												.build()
+										)
+										.build()
+						)
+						.build(),
+				UserProjectNeedsApprovalNotification.builder()
+						.id("bbb")
+						.creationDatetime(LocalDateTime.of(2014, 5, 8, 16, 29))
+						.userProject(UserProject.builder()
+								.id("def")
+								.user(User.builder()
+										.id("654321")
+										.userName("secondSubordinate")
+										.build()
+								)
+								.build()
+						)
 						.build()
 		);
 	}

--- a/src/test/java/com/tsmms/skoop/project/command/ProjectCommandServiceTests.java
+++ b/src/test/java/com/tsmms/skoop/project/command/ProjectCommandServiceTests.java
@@ -2,6 +2,7 @@ package com.tsmms.skoop.project.command;
 
 import com.tsmms.skoop.exception.DuplicateResourceException;
 import com.tsmms.skoop.exception.NoSuchResourceException;
+import com.tsmms.skoop.notification.command.NotificationCommandService;
 import com.tsmms.skoop.project.Project;
 import com.tsmms.skoop.project.ProjectRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,11 +25,14 @@ class ProjectCommandServiceTests {
 	@Mock
 	private ProjectRepository projectRepository;
 
+	@Mock
+	private NotificationCommandService notificationCommandService;
+
 	private ProjectCommandService projectCommandService;
 
 	@BeforeEach
 	void setUp() {
-		projectCommandService = new ProjectCommandService(projectRepository);
+		projectCommandService = new ProjectCommandService(projectRepository, notificationCommandService);
 	}
 
 	@Test

--- a/src/test/java/com/tsmms/skoop/project/command/ProjectCommandServiceTests.java
+++ b/src/test/java/com/tsmms/skoop/project/command/ProjectCommandServiceTests.java
@@ -5,6 +5,8 @@ import com.tsmms.skoop.exception.NoSuchResourceException;
 import com.tsmms.skoop.notification.command.NotificationCommandService;
 import com.tsmms.skoop.project.Project;
 import com.tsmms.skoop.project.ProjectRepository;
+import com.tsmms.skoop.user.User;
+import com.tsmms.skoop.userproject.UserProject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,6 +15,9 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -76,15 +81,43 @@ class ProjectCommandServiceTests {
 	}
 
 	@Test
-	@DisplayName("Tests if project is updated")
-	void testIfProjectIsUpdated() {
+	@DisplayName("The project is updated")
+	void projectIsUpdated() {
 		given(projectRepository.findById("123")).willReturn(Optional.of(
-				Project.builder().id("123").name("Project name").description("Project description").build()
+				Project.builder()
+						.id("123")
+						.name("Project name")
+						.description("Project description")
+						.userProjects(Arrays.asList(UserProject.builder()
+								.id("a")
+								.role("Software Developer")
+								.tasks("Development")
+								.startDate(LocalDate.of(2019, 5, 28))
+								.endDate(LocalDate.of(2019, 7, 30))
+								.creationDate(LocalDateTime.of(2019, 5, 28, 10, 0))
+								.lastModifiedDate(LocalDateTime.of(2019, 5, 28, 10, 0))
+								.approved(true)
+								.user(User.builder()
+										.id("1")
+										.userName("tester")
+										.build())
+								.build()))
+						.build()
 		));
 		given(projectRepository.save(ArgumentMatchers.isA(Project.class)))
-				.willReturn(Project.builder().id("123").name("New project name").description("New project description").build());
+				.willReturn(Project.builder()
+						.id("123")
+						.name("New project name")
+						.description("New project description")
+						.build()
+				);
 
-		Project project = projectCommandService.update(UpdateProjectCommand.builder().id("123").name("New project name").description("New project description").build());
+		Project project = projectCommandService.update(UpdateProjectCommand.builder()
+				.id("123")
+				.name("New project name")
+				.description("New project description")
+				.build()
+		);
 
 		assertThat(project).isNotNull();
 		assertThat(project.getId()).isNotNull();

--- a/src/test/java/com/tsmms/skoop/user/notification/UserNotificationQueryControllerTests.java
+++ b/src/test/java/com/tsmms/skoop/user/notification/UserNotificationQueryControllerTests.java
@@ -17,6 +17,8 @@ import com.tsmms.skoop.communityuser.registration.RequestToJoinCommunityNotifica
 import com.tsmms.skoop.skill.Skill;
 import com.tsmms.skoop.user.User;
 import com.tsmms.skoop.notification.query.NotificationQueryService;
+import com.tsmms.skoop.userproject.UserProject;
+import com.tsmms.skoop.userproject.UserProjectNeedsApprovalNotification;
 import com.tsmms.skoop.userskill.UserSkillsEstimationNotification;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -188,6 +190,34 @@ class UserNotificationQueryControllerTests extends AbstractControllerTests {
 										.name("Angular")
 										.build()
 						)))
+						.build(),
+				UserProjectNeedsApprovalNotification.builder()
+						.id("aaa")
+						.creationDatetime(LocalDateTime.of(2014, 5, 8, 16, 30))
+						.userProject(
+								UserProject.builder()
+										.id("abc")
+										.user(User.builder()
+												.id("123456")
+												.userName("firstSubordinate")
+												.build()
+										)
+										.build()
+						)
+						.build(),
+				UserProjectNeedsApprovalNotification.builder()
+						.id("bbb")
+						.creationDatetime(LocalDateTime.of(2014, 5, 8, 16, 29))
+						.userProject(
+								UserProject.builder()
+										.id("def")
+										.user(User.builder()
+												.id("654321")
+												.userName("secondSubordinate")
+												.build()
+										)
+										.build()
+						)
 						.build()
 		));
 
@@ -196,7 +226,7 @@ class UserNotificationQueryControllerTests extends AbstractControllerTests {
 				.with(authentication(withUser(tester))))
 				.andExpect(status().isOk())
 				.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-				.andExpect(jsonPath("$.length()", is(equalTo(10))))
+				.andExpect(jsonPath("$.length()", is(equalTo(12))))
 				.andExpect(jsonPath("$[0].id", is(equalTo("123"))))
 				.andExpect(jsonPath("$[0].type", is(equalTo("InvitationToJoinCommunityNotification"))))
 				.andExpect(jsonPath("$[0].creationDatetime", is(equalTo("2019-03-27T09:34:00"))))
@@ -271,7 +301,17 @@ class UserNotificationQueryControllerTests extends AbstractControllerTests {
 				.andExpect(jsonPath("$[9].skills[0].id", is(equalTo("123"))))
 				.andExpect(jsonPath("$[9].skills[0].name", is(equalTo("Spring Boot"))))
 				.andExpect(jsonPath("$[9].skills[1].id", is(equalTo("456"))))
-				.andExpect(jsonPath("$[9].skills[1].name", is(equalTo("Angular"))));
+				.andExpect(jsonPath("$[9].skills[1].name", is(equalTo("Angular"))))
+				.andExpect(jsonPath("$[10].id", is(equalTo("aaa"))))
+				.andExpect(jsonPath("$[10].type", is(equalTo("UserProjectNeedsApprovalNotification"))))
+				.andExpect(jsonPath("$[10].creationDatetime", is(equalTo("2014-05-08T16:30:00"))))
+				.andExpect(jsonPath("$[10].userProject.user.id", is(equalTo(("123456")))))
+				.andExpect(jsonPath("$[10].userProject.user.userName", is(equalTo(("firstSubordinate")))))
+				.andExpect(jsonPath("$[11].id", is(equalTo("bbb"))))
+				.andExpect(jsonPath("$[11].type", is(equalTo("UserProjectNeedsApprovalNotification"))))
+				.andExpect(jsonPath("$[11].creationDatetime", is(equalTo("2014-05-08T16:29:00"))))
+				.andExpect(jsonPath("$[11].userProject.user.id", is(equalTo(("654321")))))
+				.andExpect(jsonPath("$[11].userProject.user.userName", is(equalTo(("secondSubordinate")))));
 	}
 
 	@DisplayName("Not authenticated user cannot get notifications.")

--- a/src/test/java/com/tsmms/skoop/userproject/UserProjectRepositoryTests.java
+++ b/src/test/java/com/tsmms/skoop/userproject/UserProjectRepositoryTests.java
@@ -10,8 +10,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.neo4j.DataNeo4jTest;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.UUID;


### PR DESCRIPTION
`UserProjectNeedsApprovalNotification` has been implemented to notify managers when they should approve project memberships of their subordinates.

`UserProjectNeedsApprovalNotification` is created when the property `UserProject.approved` is set to `false`.
`UserProjectNeedsApprovalNotification` is created for each updated `UserProject`.
Tests.

@svetivanova could you review the changes?