### PR TITLE
feature/SKOOP-165

### DIFF
--- a/src/main/resources/config/application-prod.yml
+++ b/src/main/resources/config/application-prod.yml
@@ -34,4 +34,4 @@ security:
 skoop:
   email:
     manager-notification:
-      app-link: ${SERVER_NAME}/my-subordinates/{subordinateId}/project-memberships
+      subordinate-link-template: ${SERVER_NAME}/my-subordinates/{subordinateId}/project-memberships

--- a/src/main/resources/config/application-prod.yml
+++ b/src/main/resources/config/application-prod.yml
@@ -37,4 +37,4 @@ skoop:
       user: 0 0 */2 * * * # every two hours
   email:
     manager-notification:
-      app-link: ${SERVER_NAME}
+      app-link: ${SERVER_NAME}/my-subordinates/{subordinateId}/project-memberships

--- a/src/main/resources/config/application-prod.yml
+++ b/src/main/resources/config/application-prod.yml
@@ -32,9 +32,6 @@ security:
         jwk-set-uri: ${SECURITY_OAUTH2_RESOURCESERVER_JWT_JWKSETURI}
 
 skoop:
-  schedule:
-    reconciliation:
-      user: 0 0 */2 * * * # every two hours
   email:
     manager-notification:
       app-link: ${SERVER_NAME}/my-subordinates/{subordinateId}/project-memberships

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -39,4 +39,4 @@ spring:
 skoop:
   email:
     manager-notification:
-      app-link: 'http://localhost:4200'
+      subordinate-link-template: http://localhost:4200/my-subordinates/{subordinateId}/project-memberships

--- a/src/main/resources/templates/manager-notification-template.html
+++ b/src/main/resources/templates/manager-notification-template.html
@@ -9,8 +9,7 @@
     </head>
     <body>
         <p>Hello {managerName},</p>
-        <p>The subordinate(s) {userNames} have project memberships pending for your approval.</p>
-        <p>Please use <a href="{applicationLink}">the link</a> to approve the project memberships.</p>
+        <p>The subordinate(s) {subordinateLinks} have project memberships pending for your approval.</p>
         <p>
             Best regards,<br/>
             SKOOP team.

--- a/src/test/java/com/tsmms/skoop/email/ManagerNotificationServiceTests.java
+++ b/src/test/java/com/tsmms/skoop/email/ManagerNotificationServiceTests.java
@@ -28,7 +28,7 @@ class ManagerNotificationServiceTests {
 	void setUp() throws IOException {
 		this.managerNotificationService = new ManagerNotificationService(emailService,
 				"There are user project memberships pending for your approval.",
-				"localhost");
+				"http://localhost:4200/my-subordinates/{subordinateId}/project-memberships");
 	}
 
 	@DisplayName("Sends notification.")

--- a/tools/keycloak/skoop-realm.json
+++ b/tools/keycloak/skoop-realm.json
@@ -271,9 +271,7 @@
       "clientAuthenticatorType": "client-secret",
       "secret": "**********",
       "redirectUris": [
-        "/silent-refresh.html",
-        "/index.html",
-        "/"
+		"/*"
       ],
       "webOrigins": [],
       "notBefore": 0,


### PR DESCRIPTION
The KeyCloak realm allows all URIs corresponding to the `${test-env-domain}/*` pattern to get a user redirected to.
When notifying a manager about pending project memberships the links to subordinate memberships are embedded into an e-mail.

@georgwittberger @svetivanova could you please take a look?