### PR TITLE
feature/SKOOP-200

### DIFF
--- a/src/main/java/com/tsmms/skoop/user/UserResponse.java
+++ b/src/main/java/com/tsmms/skoop/user/UserResponse.java
@@ -8,26 +8,11 @@ import lombok.Data;
 import java.util.List;
 
 @Data
-@Builder
 @ApiModel(
 		value = "UserResponse",
 		description = "This holds extended information of a user. It will be used for sending user information to client."
 )
-public class UserResponse {
-	@ApiModelProperty("User id")
-	private String id;
-
-	@ApiModelProperty("UserName of the user. It can not be null.")
-	private String userName;
-
-	@ApiModelProperty("First name of the user.")
-	private String firstName;
-
-	@ApiModelProperty("Last name of the user.")
-	private String lastName;
-
-	@ApiModelProperty("Email of the user.")
-	private String email;
+public class UserResponse extends UserSimpleResponse {
 
 	@ApiModelProperty("Academic degree of the user.")
 	private String academicDegree;
@@ -49,6 +34,29 @@ public class UserResponse {
 
 	@ApiModelProperty("Languages which the user knows.")
 	private List<String> languages;
+
+	@Builder
+	public UserResponse(String id,
+						String userName,
+						String firstName,
+						String lastName,
+						String email,
+						String academicDegree,
+						String positionProfile,
+						String summary,
+						List<String> industrySectors,
+						List<String> specializations,
+						List<String> certificates,
+						List<String> languages) {
+		super(id, userName, firstName, lastName, email);
+		this.academicDegree = academicDegree;
+		this.positionProfile = positionProfile;
+		this.summary = summary;
+		this.industrySectors = industrySectors;
+		this.specializations = specializations;
+		this.certificates = certificates;
+		this.languages = languages;
+	}
 
 	public static UserResponse of(User user) {
 		if (user == null) {

--- a/src/main/java/com/tsmms/skoop/user/UserSimpleResponse.java
+++ b/src/main/java/com/tsmms/skoop/user/UserSimpleResponse.java
@@ -11,7 +11,6 @@ import java.util.List;
 import static java.util.stream.Collectors.toList;
 
 @Data
-@Builder
 @ApiModel(
 		value = "UserSimpleResponse",
 		description = "This holds information of a user. It will be used for sending user information to client."
@@ -33,14 +32,20 @@ public class UserSimpleResponse {
 	@ApiModelProperty("Email of the user.")
 	private String email;
 
-	@ApiModelProperty("Show as coach?")
-	private Boolean coach;
+	@Builder(builderMethodName = "userSimpleResponseBuilder")
+	public UserSimpleResponse(String id, String userName, String firstName, String lastName, String email) {
+		this.id = id;
+		this.userName = userName;
+		this.firstName = firstName;
+		this.lastName = lastName;
+		this.email = email;
+	}
 
 	public static UserSimpleResponse of(User user) {
 		if (user == null) {
 			return null;
 		}
-		return UserSimpleResponse.builder()
+		return UserSimpleResponse.userSimpleResponseBuilder()
 				.id(user.getId())
 				.userName(user.getUserName())
 				.firstName(user.getFirstName())

--- a/src/main/java/com/tsmms/skoop/user/query/UserQueryController.java
+++ b/src/main/java/com/tsmms/skoop/user/query/UserQueryController.java
@@ -82,7 +82,7 @@ public class UserQueryController {
 	})
 	@PreAuthorize("isAuthenticated()")
 	@GetMapping(path = "/users/{userId}", produces = MediaType.APPLICATION_JSON_VALUE)
-	public UserResponse getUserById(@PathVariable("userId") String userId) {
+	public UserSimpleResponse getUserById(@PathVariable("userId") String userId) {
 		final User user = userQueryService.getUserById(userId)
 				.orElseThrow(() -> {
 					String[] searchParamsMap = {"id", userId};
@@ -97,7 +97,7 @@ public class UserQueryController {
 				(user.getManager() != null && currentUserService.getCurrentUserId().equals(user.getManager().getId()))) {
 			return UserResponse.of(user);
 		} else {
-			throw new UserNotAuthorizedException();
+			return UserSimpleResponse.of(user);
 		}
 	}
 

--- a/src/test/java/com/tsmms/skoop/user/UserQueryControllerTests.java
+++ b/src/test/java/com/tsmms/skoop/user/UserQueryControllerTests.java
@@ -239,7 +239,20 @@ class UserQueryControllerTests extends AbstractControllerTests {
 		mockMvc.perform(get("/users/d9d74c04-0ab0-479c-a1d7-d372990f11b6")
 				.accept(MediaType.APPLICATION_JSON)
 				.with(authentication(withUser(owner))))
-				.andExpect(status().isForbidden());
+				.andExpect(status().isOk())
+				.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+				.andExpect(jsonPath("$.id", is(equalTo("d9d74c04-0ab0-479c-a1d7-d372990f11b6"))))
+				.andExpect(jsonPath("$.userName", is(equalTo("testing"))))
+				.andExpect(jsonPath("$.firstName", is(equalTo("Tina"))))
+				.andExpect(jsonPath("$.lastName", is(equalTo("Testing"))))
+				.andExpect(jsonPath("$.email", is(equalTo("tina.testing@skoop.io"))))
+				.andExpect(jsonPath("$.academicDegree").doesNotExist())
+				.andExpect(jsonPath("$.positionProfile").doesNotExist())
+				.andExpect(jsonPath("$.summary").doesNotExist())
+				.andExpect(jsonPath("$.industrySectors").doesNotExist())
+				.andExpect(jsonPath("$.specializations").doesNotExist())
+				.andExpect(jsonPath("$.certificates").doesNotExist())
+				.andExpect(jsonPath("$.languages").doesNotExist());
 	}
 
 	@Test


### PR DESCRIPTION
When accessing GET /users/{userId} to get user data without the permission READ_USER_PROFILE granted the UserSimpleResponse is served instead of 403 status code.
Tests adjusted.

@svetivanova could you please take a look?