### PR TITLE
feature/readme-update

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -77,7 +77,7 @@ docker run \
   --name skoop-server \
   --rm \
   -p 8080:8080 \
-  -e SMTP_SERVER_HOST=localhost \
+  -e SMTP_SERVER_HOST=smtp-server \
   -e SMTP_SERVER_PORT=25 \
   -e SERVER_NAME=skoop-server \
   -e SECURITY_OAUTH2_RESOURCESERVER_JWT_JWKSETURI=http://keycloak:8080/auth/realms/SKOOP/protocol/openid-connect/certs \

--- a/README.adoc
+++ b/README.adoc
@@ -83,7 +83,7 @@ docker run \
   -e SECURITY_OAUTH2_RESOURCESERVER_JWT_JWKSETURI=http://keycloak:8080/auth/realms/SKOOP/protocol/openid-connect/certs \
   -e SPRING_DATA_NEO4J_URI=bolt://neo4j:7687 \
   --network=skoop_nw -itd \
-  tsystemsmms/skoop-server
+  tsystemsmms/skoop-server:latest
 ----
 
 Alternatively you can still create your own after completing the Maven build. Run the following command in the project root (mind the dot at the end):
@@ -152,6 +152,7 @@ docker run ^
   -p 7474:7474 ^
   -p 7687:7687 ^
   -e NEO4J_AUTH=none ^
+  --network=skoop_nw -itd ^
   neo4j:3.4
 ----
 
@@ -164,6 +165,7 @@ docker run \
   -p 7474:7474 \
   -p 7687:7687 \
   -e NEO4J_AUTH=none \
+  --network=skoop_nw -itd \
   neo4j:3.4
 ----
 
@@ -220,6 +222,7 @@ docker run ^
   -p 9000:8080 ^
   -e KEYCLOAK_USER=admin ^
   -e KEYCLOAK_PASSWORD=admin ^
+  --network=skoop_nw -itd ^
   jboss/keycloak:4.5.0.Final
 ----
 * On Unix/Mac:
@@ -231,6 +234,7 @@ docker run \
   -p 9000:8080 \
   -e KEYCLOAK_USER=admin \
   -e KEYCLOAK_PASSWORD=admin \
+  --network=skoop_nw -itd \
   jboss/keycloak:4.5.0.Final
 ----
 

--- a/README.adoc
+++ b/README.adoc
@@ -62,7 +62,31 @@ java -jar target/skoop-server-0.0.1-SNAPSHOT.jar \
 
 === Running as Docker container
 
-We do not offer public Docker images at the moment but you can create your own after completing the Maven build. Run the following command in the project root (mind the dot at the end):
+At first you must create a network to enable the server app to connect to the database and the SKOOP web app.
+
+----
+docker network create --driver bridge skoop_nw
+----
+
+We provide https://hub.docker.com/r/tsystemsmms/skoop-server[the public Docker image] on Docker Hub.
+
+You can start the container from the public image:
+
+----
+docker run \
+  --name skoop-server \
+  --rm \
+  -p 8080:8080 \
+  -e SMTP_SERVER_HOST=localhost \
+  -e SMTP_SERVER_PORT=25 \
+  -e SERVER_NAME=skoop-server \
+  -e SECURITY_OAUTH2_RESOURCESERVER_JWT_JWKSETURI=http://keycloak:8080/auth/realms/SKOOP/protocol/openid-connect/certs \
+  -e SPRING_DATA_NEO4J_URI=bolt://neo4j:7687 \
+  --network=skoop_nw -itd \
+  tsystemsmms/skoop-server
+----
+
+Alternatively you can still create your own after completing the Maven build. Run the following command in the project root (mind the dot at the end):
 
 ----
 docker build \
@@ -78,6 +102,12 @@ docker run \
   --name skoop-server \
   --rm \
   -p 8080:8080 \
+  -e SMTP_SERVER_HOST=localhost \
+  -e SMTP_SERVER_PORT=25 \
+  -e SERVER_NAME=skoop-server \
+  -e SECURITY_OAUTH2_RESOURCESERVER_JWT_JWKSETURI=http://keycloak:8080/auth/realms/SKOOP/protocol/openid-connect/certs \
+  -e SPRING_DATA_NEO4J_URI=bolt://neo4j:7687 \
+  --network=skoop_nw -itd \
   skoop/server:latest
 ----
 

--- a/README.adoc
+++ b/README.adoc
@@ -111,6 +111,8 @@ docker run \
   skoop/server:latest
 ----
 
+Both the database and the KeyCloak server are expected to be connected to the `skoop_nw` network.
+
 === Testing the setup
 
 Once the application has started the API documentation should be available at http://localhost:8080/swagger-ui.html


### PR DESCRIPTION
The instruction on how to deploy the web app from Docker Hub image has been added.
The web app Docker container is connected with SKOOP server and KeyCloak server by means of user defined network (https://docs.docker.com/v17.09/engine/userguide/networking/#user-defined-networks).
@georgwittberger could you please take a look?