### PR TITLE
feature/SKOOP-220

### DIFF
--- a/src/main/java/com/tsmms/skoop/security/SecurityConfiguration.java
+++ b/src/main/java/com/tsmms/skoop/security/SecurityConfiguration.java
@@ -15,6 +15,7 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtDecoders;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoderJwkSupport;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
@@ -65,10 +66,8 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 		http.authorizeRequests()
 				.antMatchers(publicResourcesPatterns).permitAll()
 				.anyRequest().authenticated()
-				// TODO: Use cookie-based CSRF token repository for production
-//				.and().csrf().csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
-				.and().csrf().disable()
-				.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+				.and().csrf().csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+				.and().sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
 				.and().oauth2ResourceServer().jwt()
 				.jwtAuthenticationConverter(jwtAuthenticationConverter());
 	}

--- a/src/test/java/com/tsmms/skoop/community/command/CommunityCommandControllerTests.java
+++ b/src/test/java/com/tsmms/skoop/community/command/CommunityCommandControllerTests.java
@@ -437,7 +437,8 @@ class CommunityCommandControllerTests extends AbstractControllerTests {
 				.build();
 		given(communityQueryService.isCommunityManager(owner.getId(), "123")).willReturn(true);
 		mockMvc.perform(delete("/communities/123")
-				.with(authentication(withUser(owner))))
+				.with(authentication(withUser(owner)))
+				.with(csrf()))
 				.andExpect(status().isNoContent());
 	}
 
@@ -450,7 +451,8 @@ class CommunityCommandControllerTests extends AbstractControllerTests {
 				.build();
 		given(communityQueryService.isCommunityManager(owner.getId(), "123")).willReturn(false);
 		mockMvc.perform(delete("/communities/123")
-				.with(authentication(withUser(owner, "ADMIN"))))
+				.with(authentication(withUser(owner, "ADMIN")))
+				.with(csrf()))
 				.andExpect(status().isForbidden());
 	}
 
@@ -462,14 +464,16 @@ class CommunityCommandControllerTests extends AbstractControllerTests {
 				.userName("tester")
 				.build();
 		mockMvc.perform(delete("/communities/123")
-				.with(authentication(withUser(owner))))
+				.with(authentication(withUser(owner)))
+				.with(csrf()))
 				.andExpect(status().isForbidden());
 	}
 
 	@Test
 	@DisplayName("Tests if not authorized status code is returned when community is deleted by not authenticated user.")
 	void testIfNotAuthorizedStatusCodeIsReturnedWhenCommunityIsDeletedByNotAuthenticatedUser() throws Exception {
-		mockMvc.perform(delete("/communities/123"))
+		mockMvc.perform(delete("/communities/123")
+				.with(csrf()))
 				.andExpect(status().isUnauthorized());
 	}
 

--- a/src/test/java/com/tsmms/skoop/communityuser/command/CommunityUserCommandControllerTests.java
+++ b/src/test/java/com/tsmms/skoop/communityuser/command/CommunityUserCommandControllerTests.java
@@ -30,6 +30,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -95,7 +96,8 @@ class CommunityUserCommandControllerTests extends AbstractControllerTests {
 					.content(is.readAllBytes())
 					.accept(MediaType.APPLICATION_JSON)
 					.contentType(MediaType.APPLICATION_JSON)
-					.with(authentication(withUser(tester))))
+					.with(authentication(withUser(tester)))
+					.with(csrf()))
 					.andExpect(status().isCreated())
 					.andExpect(jsonPath("$.role", is(equalTo(CommunityRole.MEMBER.toString()))))
 					.andExpect(jsonPath("$.user.id", is(equalTo("1f37fb2a-b4d0-4119-9113-4677beb20ae2"))))
@@ -120,7 +122,8 @@ class CommunityUserCommandControllerTests extends AbstractControllerTests {
 					.content(is.readAllBytes())
 					.accept(MediaType.APPLICATION_JSON)
 					.contentType(MediaType.APPLICATION_JSON)
-					.with(authentication(withUser(tester))))
+					.with(authentication(withUser(tester)))
+					.with(csrf()))
 					.andExpect(status().isNotFound());
 		}
 	}
@@ -150,7 +153,8 @@ class CommunityUserCommandControllerTests extends AbstractControllerTests {
 					.content(is.readAllBytes())
 					.accept(MediaType.APPLICATION_JSON)
 					.contentType(MediaType.APPLICATION_JSON)
-					.with(authentication(withUser(tester))))
+					.with(authentication(withUser(tester)))
+					.with(csrf()))
 					.andExpect(status().isNotFound());
 		}
 	}
@@ -181,7 +185,8 @@ class CommunityUserCommandControllerTests extends AbstractControllerTests {
 					.content(is.readAllBytes())
 					.accept(MediaType.APPLICATION_JSON)
 					.contentType(MediaType.APPLICATION_JSON)
-					.with(authentication(withUser(tester))))
+					.with(authentication(withUser(tester)))
+					.with(csrf()))
 					.andExpect(status().isForbidden());
 		}
 	}
@@ -221,7 +226,8 @@ class CommunityUserCommandControllerTests extends AbstractControllerTests {
 					.content(is.readAllBytes())
 					.accept(MediaType.APPLICATION_JSON)
 					.contentType(MediaType.APPLICATION_JSON)
-					.with(authentication(withUser(tester))))
+					.with(authentication(withUser(tester)))
+					.with(csrf()))
 					.andExpect(status().isForbidden());
 		}
 	}
@@ -333,7 +339,8 @@ class CommunityUserCommandControllerTests extends AbstractControllerTests {
 					.content(is.readAllBytes())
 					.accept(MediaType.APPLICATION_JSON)
 					.contentType(MediaType.APPLICATION_JSON)
-					.with(authentication(withUser(tester))))
+					.with(authentication(withUser(tester)))
+					.with(csrf()))
 					.andExpect(status().isCreated())
 					.andExpect(jsonPath("$.role", is(equalTo(CommunityRole.MEMBER.toString()))))
 					.andExpect(jsonPath("$.user.id", is(equalTo("1f37fb2a-b4d0-4119-9113-4677beb20ae2"))))
@@ -369,7 +376,8 @@ class CommunityUserCommandControllerTests extends AbstractControllerTests {
 					.content(is.readAllBytes())
 					.accept(MediaType.APPLICATION_JSON)
 					.contentType(MediaType.APPLICATION_JSON)
-					.with(authentication(withUser(owner))))
+					.with(authentication(withUser(owner)))
+					.with(csrf()))
 					.andExpect(status().isOk())
 					.andExpect(jsonPath("$.role", is(equalTo(CommunityRole.MANAGER.toString()))))
 					.andExpect(jsonPath("$.user.id", is(equalTo("4f09647e-c7d3-4aa6-ab3d-0faff66b951f"))))
@@ -394,7 +402,8 @@ class CommunityUserCommandControllerTests extends AbstractControllerTests {
 					.content(is.readAllBytes())
 					.accept(MediaType.APPLICATION_JSON)
 					.contentType(MediaType.APPLICATION_JSON)
-					.with(authentication(withUser(owner))))
+					.with(authentication(withUser(owner)))
+					.with(csrf()))
 					.andExpect(status().isForbidden());
 		}
 	}
@@ -407,7 +416,8 @@ class CommunityUserCommandControllerTests extends AbstractControllerTests {
 		try (InputStream is = body.getInputStream()) {
 			mockMvc.perform(put("/communities/123/users/4f09647e-c7d3-4aa6-ab3d-0faff66b951f")
 					.content(is.readAllBytes())
-					.contentType(MediaType.APPLICATION_JSON))
+					.contentType(MediaType.APPLICATION_JSON)
+					.with(csrf()))
 					.andExpect(status().isUnauthorized());
 		}
 	}
@@ -427,7 +437,8 @@ class CommunityUserCommandControllerTests extends AbstractControllerTests {
 					.content(is.readAllBytes())
 					.accept(MediaType.APPLICATION_JSON)
 					.contentType(MediaType.APPLICATION_JSON)
-					.with(authentication(withUser(owner))))
+					.with(authentication(withUser(owner)))
+					.with(csrf()))
 					.andExpect(status().isForbidden());
 		}
 	}
@@ -449,7 +460,8 @@ class CommunityUserCommandControllerTests extends AbstractControllerTests {
 					.content(is.readAllBytes())
 					.accept(MediaType.APPLICATION_JSON)
 					.contentType(MediaType.APPLICATION_JSON)
-					.with(authentication(withUser(owner))))
+					.with(authentication(withUser(owner)))
+					.with(csrf()))
 					.andExpect(status().isBadRequest());
 		}
 	}
@@ -457,7 +469,8 @@ class CommunityUserCommandControllerTests extends AbstractControllerTests {
 	@Test
 	@DisplayName("Not authenticated user is not allowed to join the community.")
 	void notAuthenticatedUserIsNotAllowedToJoinCommunity() throws Exception {
-		mockMvc.perform(post("/communities/123/users"))
+		mockMvc.perform(post("/communities/123/users")
+				.with(csrf()))
 				.andExpect(status().isUnauthorized());
 	}
 
@@ -472,14 +485,16 @@ class CommunityUserCommandControllerTests extends AbstractControllerTests {
 		given(communityQueryService.isCommunityManager(owner.getId(), "123")).willReturn(false);
 
 		mockMvc.perform(delete("/communities/123/users/1f37fb2a-b4d0-4119-9113-4677beb20ae2")
-				.with(authentication(withUser(owner))))
+				.with(authentication(withUser(owner)))
+				.with(csrf()))
 				.andExpect(status().isNoContent());
 	}
 
 	@Test
 	@DisplayName("Not authenticated user is not allowed to leave the community.")
 	void notAuthenticatedUserIsNotAllowedToLeaveCommunity() throws Exception {
-		mockMvc.perform(delete("/communities/123/members"))
+		mockMvc.perform(delete("/communities/123/members")
+				.with(csrf()))
 				.andExpect(status().isUnauthorized());
 	}
 
@@ -494,7 +509,8 @@ class CommunityUserCommandControllerTests extends AbstractControllerTests {
 		given(communityQueryService.isCommunityManager(owner.getId(), "123")).willReturn(true);
 
 		mockMvc.perform(delete("/communities/123/users/a396d5a8-a6b1-4c71-9498-a16e655dae2e")
-				.with(authentication(withUser(owner))))
+				.with(authentication(withUser(owner)))
+				.with(csrf()))
 				.andExpect(status().isNoContent());
 	}
 
@@ -509,7 +525,8 @@ class CommunityUserCommandControllerTests extends AbstractControllerTests {
 		given(communityQueryService.isCommunityManager(owner.getId(), "123")).willReturn(true);
 
 		mockMvc.perform(delete("/communities/123/users/1f37fb2a-b4d0-4119-9113-4677beb20ae2")
-				.with(authentication(withUser(owner))))
+				.with(authentication(withUser(owner)))
+				.with(csrf()))
 				.andExpect(status().isForbidden());
 	}
 
@@ -524,7 +541,8 @@ class CommunityUserCommandControllerTests extends AbstractControllerTests {
 		given(communityQueryService.isCommunityManager(owner.getId(), "123")).willReturn(false);
 
 		mockMvc.perform(delete("/communities/123/users/a396d5a8-a6b1-4c71-9498-a16e655dae2e")
-				.with(authentication(withUser(owner))))
+				.with(authentication(withUser(owner)))
+				.with(csrf()))
 				.andExpect(status().isForbidden());
 	}
 

--- a/src/test/java/com/tsmms/skoop/communityuser/registration/command/CommunityUserRegistrationCommandControllerTests.java
+++ b/src/test/java/com/tsmms/skoop/communityuser/registration/command/CommunityUserRegistrationCommandControllerTests.java
@@ -33,6 +33,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -126,7 +127,8 @@ class CommunityUserRegistrationCommandControllerTests extends AbstractController
 			mockMvc.perform(post("/communities/123/user-registrations").content(is.readAllBytes())
 					.accept(MediaType.APPLICATION_JSON)
 					.contentType(MediaType.APPLICATION_JSON)
-					.with(authentication(withUser(tester))))
+					.with(authentication(withUser(tester)))
+					.with(csrf()))
 					.andExpect(status().isCreated())
 					.andExpect(jsonPath("$[0].user.userName", is(equalTo("firstUser"))))
 					.andExpect(jsonPath("$[0].approvedByUser", nullValue()))
@@ -185,7 +187,8 @@ class CommunityUserRegistrationCommandControllerTests extends AbstractController
 			mockMvc.perform(post("/communities/123/user-registrations").content(is.readAllBytes())
 					.accept(MediaType.APPLICATION_JSON)
 					.contentType(MediaType.APPLICATION_JSON)
-					.with(authentication(withUser(tester))))
+					.with(authentication(withUser(tester)))
+					.with(csrf()))
 					.andExpect(status().isCreated())
 					.andExpect(jsonPath("$[0].user.userName", is(equalTo("tester"))))
 					.andExpect(jsonPath("$[0].approvedByUser", is(equalTo(true))))
@@ -252,7 +255,8 @@ class CommunityUserRegistrationCommandControllerTests extends AbstractController
 			mockMvc.perform(post("/communities/123/user-registrations").content(is.readAllBytes())
 					.accept(MediaType.APPLICATION_JSON)
 					.contentType(MediaType.APPLICATION_JSON)
-					.with(authentication(withUser(tester))))
+					.with(authentication(withUser(tester)))
+					.with(csrf()))
 					.andExpect(status().isCreated())
 					.andExpect(jsonPath("$[0].user.userName", is(equalTo("tester"))))
 					.andExpect(jsonPath("$[0].approvedByUser", is(equalTo(true))))
@@ -328,7 +332,8 @@ class CommunityUserRegistrationCommandControllerTests extends AbstractController
 			mockMvc.perform(post("/communities/123/user-registrations").content(is.readAllBytes())
 					.accept(MediaType.APPLICATION_JSON)
 					.contentType(MediaType.APPLICATION_JSON)
-					.with(authentication(withUser(tester))))
+					.with(authentication(withUser(tester)))
+					.with(csrf()))
 					.andExpect(status().isCreated())
 					.andExpect(jsonPath("$[0].user.userName", is(equalTo("firstUser"))))
 					.andExpect(jsonPath("$[0].approvedByUser", nullValue()))
@@ -375,7 +380,8 @@ class CommunityUserRegistrationCommandControllerTests extends AbstractController
 			mockMvc.perform(post("/communities/123/user-registrations").content(is.readAllBytes())
 					.accept(MediaType.APPLICATION_JSON)
 					.contentType(MediaType.APPLICATION_JSON)
-					.with(authentication(withUser(tester))))
+					.with(authentication(withUser(tester)))
+					.with(csrf()))
 					.andExpect(status().isForbidden());
 		}
 	}
@@ -409,7 +415,8 @@ class CommunityUserRegistrationCommandControllerTests extends AbstractController
 			mockMvc.perform(post("/communities/123/user-registrations").content(is.readAllBytes())
 					.accept(MediaType.APPLICATION_JSON)
 					.contentType(MediaType.APPLICATION_JSON)
-					.with(authentication(withUser(tester))))
+					.with(authentication(withUser(tester)))
+					.with(csrf()))
 					.andExpect(status().isNotFound());
 		}
 	}
@@ -444,7 +451,8 @@ class CommunityUserRegistrationCommandControllerTests extends AbstractController
 			mockMvc.perform(post("/communities/123/user-registrations").content(is.readAllBytes())
 					.accept(MediaType.APPLICATION_JSON)
 					.contentType(MediaType.APPLICATION_JSON)
-					.with(authentication(withUser(tester))))
+					.with(authentication(withUser(tester)))
+					.with(csrf()))
 					.andExpect(status().isForbidden());
 		}
 	}
@@ -521,7 +529,8 @@ class CommunityUserRegistrationCommandControllerTests extends AbstractController
 			mockMvc.perform(put("/communities/123/user-registrations/456").content(is.readAllBytes())
 					.accept(MediaType.APPLICATION_JSON)
 					.contentType(MediaType.APPLICATION_JSON)
-					.with(authentication(withUser(tester))))
+					.with(authentication(withUser(tester)))
+					.with(csrf()))
 					.andExpect(status().isOk())
 					.andExpect(jsonPath("$.user.userName", is(equalTo("tester"))))
 					.andExpect(jsonPath("$.approvedByUser", is(equalTo(true))))
@@ -603,7 +612,8 @@ class CommunityUserRegistrationCommandControllerTests extends AbstractController
 			mockMvc.perform(put("/communities/123/user-registrations/456").content(is.readAllBytes())
 					.accept(MediaType.APPLICATION_JSON)
 					.contentType(MediaType.APPLICATION_JSON)
-					.with(authentication(withUser(tester))))
+					.with(authentication(withUser(tester)))
+					.with(csrf()))
 					.andExpect(status().isOk())
 					.andExpect(jsonPath("$.user.userName", is(equalTo("anotherTester"))))
 					.andExpect(jsonPath("$.approvedByUser", is(equalTo(true))))
@@ -624,7 +634,8 @@ class CommunityUserRegistrationCommandControllerTests extends AbstractController
 			mockMvc.perform(put("/communities/123/user-registrations/456").content(is.readAllBytes())
 					.accept(MediaType.APPLICATION_JSON)
 					.contentType(MediaType.APPLICATION_JSON)
-					.with(authentication(withUser(tester))))
+					.with(authentication(withUser(tester)))
+					.with(csrf()))
 					.andExpect(status().isNotFound());
 		}
 	}
@@ -664,7 +675,8 @@ class CommunityUserRegistrationCommandControllerTests extends AbstractController
 			mockMvc.perform(put("/communities/123/user-registrations/456").content(is.readAllBytes())
 					.accept(MediaType.APPLICATION_JSON)
 					.contentType(MediaType.APPLICATION_JSON)
-					.with(authentication(withUser(tester))))
+					.with(authentication(withUser(tester)))
+					.with(csrf()))
 					.andExpect(status().isForbidden());
 		}
 	}

--- a/src/test/java/com/tsmms/skoop/notification/command/NotificationCommandControllerTests.java
+++ b/src/test/java/com/tsmms/skoop/notification/command/NotificationCommandControllerTests.java
@@ -23,6 +23,7 @@ import java.util.stream.Stream;
 
 import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static com.tsmms.skoop.common.JwtAuthenticationFactory.withUser;
@@ -124,7 +125,8 @@ class NotificationCommandControllerTests extends AbstractControllerTests {
 		);
 		mockMvc.perform(delete("/notifications/789")
 				.accept(MediaType.APPLICATION_JSON)
-				.with(authentication(withUser(tester))))
+				.with(authentication(withUser(tester)))
+				.with(csrf()))
 				.andExpect(status().isNoContent());
 	}
 
@@ -198,7 +200,8 @@ class NotificationCommandControllerTests extends AbstractControllerTests {
 		);
 		mockMvc.perform(delete("/notifications/789")
 				.accept(MediaType.APPLICATION_JSON)
-				.with(authentication(withUser(tester))))
+				.with(authentication(withUser(tester)))
+				.with(csrf()))
 				.andExpect(status().isForbidden());
 	}
 
@@ -291,7 +294,8 @@ class NotificationCommandControllerTests extends AbstractControllerTests {
 		);
 		mockMvc.perform(delete("/notifications/123")
 				.accept(MediaType.APPLICATION_JSON)
-				.with(authentication(withUser(tester))))
+				.with(authentication(withUser(tester)))
+				.with(csrf()))
 				.andExpect(status().isForbidden());
 	}
 
@@ -305,7 +309,8 @@ class NotificationCommandControllerTests extends AbstractControllerTests {
 		given(notificationQueryService.getNotification("123")).willReturn(Optional.empty());
 		mockMvc.perform(delete("/notifications/123")
 				.accept(MediaType.APPLICATION_JSON)
-				.with(authentication(withUser(tester))))
+				.with(authentication(withUser(tester)))
+				.with(csrf()))
 				.andExpect(status().isNotFound());
 	}
 
@@ -314,7 +319,8 @@ class NotificationCommandControllerTests extends AbstractControllerTests {
 	void unauthenticatedUserCannotDeleteNotification() throws Exception {
 		given(notificationQueryService.getNotification("123")).willReturn(Optional.empty());
 		mockMvc.perform(delete("/notifications/123")
-				.accept(MediaType.APPLICATION_JSON))
+				.accept(MediaType.APPLICATION_JSON)
+				.with(csrf()))
 				.andExpect(status().isUnauthorized());
 	}
 

--- a/src/test/java/com/tsmms/skoop/userproject/command/UserProjectCommandControllerTests.java
+++ b/src/test/java/com/tsmms/skoop/userproject/command/UserProjectCommandControllerTests.java
@@ -144,7 +144,8 @@ class UserProjectCommandControllerTests extends AbstractControllerTests {
 				.userName("tester")
 				.build();
 		mockMvc.perform(delete("/users/1f37fb2a-b4d0-4119-9113-4677beb20ae2/projects/123")
-				.with(authentication(withUser(owner))))
+				.with(authentication(withUser(owner)))
+				.with(csrf()))
 				.andExpect(status().isNoContent());
 	}
 
@@ -156,14 +157,16 @@ class UserProjectCommandControllerTests extends AbstractControllerTests {
 				.userName("tester")
 				.build();
 		mockMvc.perform(delete("/users/1f37cb2a-a5d0-f229-8634-4647beb20ae2/projects/123")
-				.with(authentication(withUser(owner))))
+				.with(authentication(withUser(owner)))
+				.with(csrf()))
 				.andExpect(status().isForbidden());
 	}
 
 	@Test
 	@DisplayName("Tests if user project relationship cannot be deleted by not authenticated user.")
 	void testIfUserProjectCannotBeDeletedByNotAuthenticatedUser() throws Exception {
-		mockMvc.perform(delete("/users/1f37cb2a-a5d0-f229-8634-4647beb20ae2/projects/123"))
+		mockMvc.perform(delete("/users/1f37cb2a-a5d0-f229-8634-4647beb20ae2/projects/123")
+				.with(csrf()))
 				.andExpect(status().isUnauthorized());
 	}
 


### PR DESCRIPTION
The cookie-based CSRF protection was enabled.
Tests adjusted.
`com.tsmms.skoop.project.command.ProjectCommandControllerTests#projectCannotBeCreatedWhenCsrfTokenIsNotPresent`, `com.tsmms.skoop.project.command.ProjectCommandControllerTests#projectCannotBeCreatedWhenInvalidCsrfTokenIsUsed` were added to test if CSRF protection works.
@svetivanova  @georgwittberger  could you please take a look?